### PR TITLE
Fix #16 changing Reverb Url system config value to be a dropdown, not…

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Model/Source/Revurl.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Source/Revurl.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Author: Sean Dunagan
+ * Created: 9/9/15
+ */
+
+class Reverb_ReverbSync_Model_Source_Revurl
+{
+    const PRODUCTION_URL = 'https://reverb.com';
+    const PRODUCTION_LABEL = 'Reverb.com';
+    const SANDBOX_URL = 'https://sandbox.reverb.com';
+    const SANDBOX_LABEL = 'Reverb Sandbox (Testing)';
+
+    /**
+     * Options getter
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return array(
+            array('value' => self::PRODUCTION_URL, 'label' => Mage::helper('ReverbSync')->__(self::PRODUCTION_LABEL)),
+            array('value' => self::SANDBOX_URL, 'label' => Mage::helper('ReverbSync')->__(self::SANDBOX_LABEL)),
+        );
+    }
+
+    /**
+     * Get options in "key-value" format
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array(
+            self::PRODUCTION_URL => Mage::helper('ReverbSync')->__(self::PRODUCTION_LABEL),
+            self::SANDBOX_URL => Mage::helper('ReverbSync')->__(self::SANDBOX_LABEL),
+        );
+    }
+}

--- a/app/code/community/Reverb/ReverbSync/etc/config.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/config.xml
@@ -168,7 +168,7 @@
         <revInvent>1</revInvent>
       </reverbDefault>
       <extension>
-        <revUrl>https://reverb.com</revUrl>
+        <revUrl>https://sandbox.reverb.com</revUrl>
       </extension>
     </ReverbSync>
   </default>

--- a/app/code/community/Reverb/ReverbSync/etc/system.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/system.xml
@@ -46,13 +46,14 @@
           <show_in_store>1</show_in_store>
           <fields>
             <revUrl translate="label">
-              <label>Reverb URL (change to https://sandbox.reverb.com for testing)*:</label>
-              <frontend_type>text</frontend_type>
+              <label>Reverb URL (change to Reverb Sandbox (Testing) for testing)*:</label>
+              <frontend_type>select</frontend_type>
               <sort_order>1</sort_order>
               <show_in_default>1</show_in_default>
               <show_in_website>1</show_in_website>
               <show_in_store>1</show_in_store>
               <validate>input-text required-entry</validate>
+              <source_model>reverbSync/source_revurl</source_model>
             </revUrl>
             <api_token translate="label">
               <label>API Token (from bottom of https://reverb.com/my/account/settings)*:</label>


### PR DESCRIPTION
Fix #16 The legacy code had a label "Reverb URL (change to https://sandbox.reverb.com for testing)*:" which I updated to say "Reverb URL (change to Reverb Sandbox (Testing) for testing)". However for safety purposes, I updated the default value for the URL to be the sandbox url. Let me know if you want me to update the label to give directions on changing the URL to production