### PR TITLE
Fix #65 Allowing admins to toggle Super Mode for order creation

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Creation.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Creation.php
@@ -21,8 +21,12 @@ class Reverb_ReverbSync_Helper_Orders_Creation extends Reverb_ReverbSync_Helper_
         }
 
         $quoteToBuild = Mage::getModel('sales/quote');
-        // Process this quote as though we were an admin in the admin panel
-        $quoteToBuild->setIsSuperMode(true);
+
+        if (Mage::helper('ReverbSync/orders_sync')->isOrderSyncSuperModeEnabled())
+        {
+            // Process this quote as though we were an admin in the admin panel
+            $quoteToBuild->setIsSuperMode(true);
+        }
 
         $productToAddToQuote = $this->_getProductToAddToQuote($reverbOrderObject);
         $qty = $reverbOrderObject->quantity;

--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Sync.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Sync.php
@@ -8,6 +8,7 @@ class Reverb_ReverbSync_Helper_Orders_Sync extends Mage_Core_Helper_Abstract
 {
     const ORDER_SYNC_DISABLED_MESSAGE = 'Order Sync Is Not Enabled in System -> Configuration -> Reverb Configuration -> Order Sync -> Enable Order Sync';
     const ORDER_SYNC_ENABLED_CONFIG_PATH = 'ReverbSync/orders_sync/enabled';
+    const ORDER_SYNC_SUPER_MODE_ENABLED_CONFIG_PATH = 'ReverbSync/orders_sync/super_mode_enabled';
 
     const ORDER_UPDATE_SYNC_ACL_PATH = 'sales/reverb_order_task_sync_update';
     const ORDER_CREATION_SYNC_ACL_PATH = 'sales/reverb_order_unique_task_sync_update';
@@ -29,6 +30,11 @@ class Reverb_ReverbSync_Helper_Orders_Sync extends Mage_Core_Helper_Abstract
     public function isOrderSyncEnabled()
     {
         return Mage::getStoreConfig(self::ORDER_SYNC_ENABLED_CONFIG_PATH);
+    }
+
+    public function isOrderSyncSuperModeEnabled()
+    {
+        return Mage::getStoreConfig(self::ORDER_SYNC_SUPER_MODE_ENABLED_CONFIG_PATH);
     }
 
     public function logOrderSyncDisabledMessage()

--- a/app/code/community/Reverb/ReverbSync/etc/config.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/config.xml
@@ -202,19 +202,20 @@
         </events>
     </crontab>
 
-  <default>
-    <ReverbSync>
-      <reverbDefault>
-        <enable_listing_creation>0</enable_listing_creation>
-        <revCond>Brand New</revCond>
-        <revInvent>1</revInvent>
-      </reverbDefault>
-      <extension>
-        <revUrl>https://sandbox.reverb.com</revUrl>
-      </extension>
-        <orders_sync>
-            <enabled>0</enabled>
-        </orders_sync>
-    </ReverbSync>
-  </default>
+    <default>
+        <ReverbSync>
+            <reverbDefault>
+                <enable_listing_creation>0</enable_listing_creation>
+                <revCond>Brand New</revCond>
+                <revInvent>1</revInvent>
+            </reverbDefault>
+            <extension>
+                <revUrl>https://sandbox.reverb.com</revUrl>
+            </extension>
+            <orders_sync>
+                <enabled>0</enabled>
+                <super_mode_enabled>0</super_mode_enabled>
+            </orders_sync>
+        </ReverbSync>
+    </default>
 </config>

--- a/app/code/community/Reverb/ReverbSync/etc/system.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/system.xml
@@ -138,6 +138,17 @@
                     <source_model>adminhtml/system_config_source_yesno</source_model>
                     <validate>input-text required-entry</validate>
                 </enabled>
+                <super_mode_enabled translate="label">
+                    <label>Override Product Inventory/Status Checks</label>
+                    <comment>Set to "Yes" to ignore all product inventory/availability checks while syncing orders</comment>
+                    <frontend_type>select</frontend_type>
+                    <sort_order>40</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <source_model>adminhtml/system_config_source_yesno</source_model>
+                    <validate>input-text required-entry</validate>
+                </super_mode_enabled>
             </fields>
         </orders_sync>
       </groups>


### PR DESCRIPTION
Fix #65 

This patch allow admins to toggle whether super mode should be enabled for the order creation sync process