### PR TITLE
Feature/order view screen updates

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Creation.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Creation.php
@@ -21,6 +21,7 @@ class Reverb_ReverbSync_Helper_Orders_Creation extends Reverb_ReverbSync_Helper_
         }
 
         $quoteToBuild = Mage::getModel('sales/quote');
+        $reverb_order_number = $reverbOrderObject->order_number;
 
         if (Mage::helper('ReverbSync/orders_sync')->isOrderSyncSuperModeEnabled())
         {
@@ -39,8 +40,7 @@ class Reverb_ReverbSync_Helper_Orders_Creation extends Reverb_ReverbSync_Helper_
 
         $this->_addTaxAndCurrencyToQuoteItem($quoteToBuild, $reverbOrderObject);
 
-        $magentoCustomerObject = Mage::getModel('customer/customer');
-        $quoteToBuild->setCustomer($magentoCustomerObject);
+        $this->_getCustomerHelper()->addCustomerToQuote($reverbOrderObject, $quoteToBuild);
 
         $this->_getAddressHelper()->addOrderAddressAsShippingAndBillingToQuote($reverbOrderObject, $quoteToBuild);
         $this->_getShippingHelper()->setShippingMethodAndRateOnQuote($reverbOrderObject, $quoteToBuild);
@@ -52,7 +52,6 @@ class Reverb_ReverbSync_Helper_Orders_Creation extends Reverb_ReverbSync_Helper_
 
         $order = $service->getOrder();
 
-        $reverb_order_number = $reverbOrderObject->order_number;
         $order->setReverbOrderId($reverb_order_number);
 
         $reverb_order_status = $reverbOrderObject->status;

--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Creation/Address.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Creation/Address.php
@@ -63,25 +63,8 @@ class Reverb_ReverbSync_Helper_Orders_Creation_Address extends Reverb_ReverbSync
     protected function _getCustomerAddressForOrder(stdClass $shippingAddressObject)
     {
         $name = $shippingAddressObject->name;
-        $exploded_name = explode(' ', $name);
-        $first_name = array_shift($exploded_name);
-        if (empty($exploded_name))
-        {
-            // Only one word was provided in the name field, default last name to "Customer"
-            $last_name = "Customer";
-            $middle_name = '';
-        }
-        else if (count($exploded_name) > 1)
-        {
-            // Middle name was provided
-            $middle_name = array_shift($exploded_name);
-            $last_name = implode(' ', $exploded_name);
-        }
-        else
-        {
-            $middle_name = '';
-            $last_name = implode(' ', $exploded_name);
-        }
+
+        list($first_name, $middle_name, $last_name) = $this->getExplodedNameFields($name);
 
         $street_address = $shippingAddressObject->street_address;
         $extended_address = $shippingAddressObject->extended_address;

--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Creation/Customer.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Creation/Customer.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Author: Sean Dunagan
+ * Created: 9/18/15
+ */
+
+class Customer {
+
+} 

--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Creation/Customer.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Creation/Customer.php
@@ -4,6 +4,33 @@
  * Created: 9/18/15
  */
 
-class Customer {
+class Reverb_ReverbSync_Helper_Orders_Creation_Customer extends Reverb_ReverbSync_Helper_Orders_Creation_Sync
+{
+    const EXCEPTION_ADDING_CUSTOMER_NAME = 'An error occurred while trying to add the buyer\'s name to the quote while creating order with Reverb id #%s: %s';
 
-} 
+    public function addCustomerToQuote(stdClass $reverbOrderObject, Mage_Sales_Model_Quote $quoteToBuild)
+    {
+        $magentoCustomerObject = Mage::getModel('customer/customer');
+        $reverb_order_number = $reverbOrderObject->order_number;
+
+        try
+        {
+            if (isset($reverbOrderObject->buyer_name))
+            {
+                $buyer_name_string = $reverbOrderObject->buyer_name;
+                list($first_name, $middle_name, $last_name) = $this->getExplodedNameFields($buyer_name_string);
+                $magentoCustomerObject->setFirstname($first_name);
+                $magentoCustomerObject->setMiddlename($middle_name);
+                $magentoCustomerObject->setLastname($last_name);
+            }
+        }
+        catch(Exception $e)
+        {
+            $error_message = $this->__(self::EXCEPTION_ADDING_CUSTOMER_NAME, $reverb_order_number, $e->getMessage());
+            $this->_logOrderSyncError($error_message);
+        }
+
+        $quoteToBuild->setCustomer($magentoCustomerObject);
+        return true;
+    }
+}

--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Creation/Helper.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Creation/Helper.php
@@ -11,6 +11,7 @@ class Reverb_ReverbSync_Helper_Orders_Creation_Helper extends Mage_Core_Helper_A
     protected $_shippingHelper = null;
     protected $_paymentHelper = null;
     protected $_addressHelper = null;
+    protected $_customerHelper = null;
 
     protected function _getShippingHelper()
     {
@@ -40,5 +41,45 @@ class Reverb_ReverbSync_Helper_Orders_Creation_Helper extends Mage_Core_Helper_A
         }
 
         return $this->_addressHelper;
+    }
+
+    protected function _getCustomerHelper()
+    {
+        if (is_null($this->_customerHelper))
+        {
+            $this->_customerHelper = Mage::helper('ReverbSync/orders_creation_customer');
+        }
+
+        return $this->_customerHelper;
+    }
+
+    public function getExplodedNameFields($name_as_string)
+    {
+        $exploded_name = explode(' ', $name_as_string);
+        $first_name = array_shift($exploded_name);
+        if (empty($exploded_name))
+        {
+            // Only one word was provided in the name field, default last name to "Customer"
+            $last_name = "Customer";
+            $middle_name = '';
+        }
+        else if (count($exploded_name) > 1)
+        {
+            // Middle name was provided
+            $middle_name = array_shift($exploded_name);
+            $last_name = implode(' ', $exploded_name);
+        }
+        else
+        {
+            $middle_name = '';
+            $last_name = implode(' ', $exploded_name);
+        }
+
+        return array($first_name, $middle_name, $last_name);
+    }
+
+    protected function _logOrderSyncError($error_message)
+    {
+        Mage::getSingleton('reverbSync/log')->logOrderSyncError($error_message);
     }
 }

--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Layout.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Layout.php
@@ -16,5 +16,8 @@ class Reverb_ReverbSync_Helper_Orders_Layout
             // This would only be false if a third-party extension modified this page's layout
             $salesOrderTabsBlock->addTab('reverb_sync', $reverbOrderTabBlock);
         }
+
+        $orderInfoBlock = Mage::app()->getLayout()->getBlock('order_info');
+        $orderInfoBlock->setTemplate('ReverbSync/sales/order/view/info.phtml');
     }
 }

--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Layout.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Layout.php
@@ -20,4 +20,10 @@ class Reverb_ReverbSync_Helper_Orders_Layout
         $orderInfoBlock = Mage::app()->getLayout()->getBlock('order_info');
         $orderInfoBlock->setTemplate('ReverbSync/sales/order/view/info.phtml');
     }
+
+    public function updateAdminOrderViewLayoutForReverbOrderInvoice($reverbOrder)
+    {
+        $orderInfoBlock = Mage::app()->getLayout()->getBlock('order_info');
+        $orderInfoBlock->setTemplate('ReverbSync/sales/order/view/info.phtml');
+    }
 }

--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/View.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/View.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Author: Sean Dunagan
+ * Created: 9/18/15
+ */
+
+class Reverb_ReverbSync_Helper_Orders_View
+{
+    public function getStoreNameForReverbOrder($reverbOrder)
+    {
+        if (is_object($reverbOrder) && $reverbOrder->getId())
+        {
+            $store_name = $reverbOrder->getStoreName();
+            if (!empty($store_name))
+            {
+                return $store_name;
+            }
+        }
+        // The store name should always be set, but handle the case where it isn't
+        $orderInfoBlock = Mage::app()->getLayout()->getBlock('order_info');
+        return $orderInfoBlock->getOrderStoreName();
+    }
+
+    public function getReverbOrderId($reverbOrder)
+    {
+        if (is_object($reverbOrder) && $reverbOrder->getId())
+        {
+            return $reverbOrder->getReverbOrderId();
+        }
+        // This should never happen, but handle the case where it does
+        return '';
+    }
+
+    public function getReverbOrderStatus($reverbOrder)
+    {
+        if (is_object($reverbOrder) && $reverbOrder->getId())
+        {
+            return $reverbOrder->getReverbOrderStatus();
+        }
+        // This should never happen, but handle the case where it does
+        return '';
+    }
+}

--- a/app/code/community/Reverb/ReverbSync/Model/Mysql4/Order.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Mysql4/Order.php
@@ -30,4 +30,14 @@ class Reverb_ReverbSync_Model_Mysql4_Order extends Mage_Sales_Model_Mysql4_Order
                             ->update($this->getMainTable(), $update_bind_array, $where_conditions_array);
         return $rows_updated;
     }
+
+    public function setReverbStoreNameByReverbOrderId($reverb_order_id, $store_name)
+    {
+        $update_bind_array = array('store_name' => $store_name);
+        $where_conditions_array = array('reverb_order_id=?' => $reverb_order_id);
+
+        $rows_updated = $this->_getWriteAdapter()
+                            ->update($this->getMainTable(), $update_bind_array, $where_conditions_array);
+        return $rows_updated;
+    }
 }

--- a/app/code/community/Reverb/ReverbSync/Model/Observer/Orders.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Observer/Orders.php
@@ -50,6 +50,24 @@ class Reverb_ReverbSync_Model_Observer_Orders
         }
     }
 
+    public function updateAdminOrderViewForReverbOrderInvoices($observer)
+    {
+        $orderInvoice = Mage::registry('current_invoice');
+        if (is_object($orderInvoice) && $orderInvoice->getId())
+        {
+            $order = $orderInvoice->getOrder();
+            if (is_object($order) && $order->getId())
+            {
+                $reverb_order_id = $order->getReverbOrderId();
+                if (!empty($reverb_order_id))
+                {
+                    Mage::helper('ReverbSync/orders_layout')
+                        ->updateAdminOrderViewLayoutForReverbOrderInvoice($order);
+                }
+            }
+        }
+    }
+
     protected function _getReverbShippingHelper()
     {
         if (is_null($this->_reverbShippingHelper))

--- a/app/code/community/Reverb/ReverbSync/etc/config.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/config.xml
@@ -133,6 +133,16 @@
                 </update_layout_for_reverb_order>
             </observers>
         </controller_action_layout_render_before_adminhtml_sales_order_view>
+
+        <controller_action_layout_render_before_adminhtml_sales_order_invoice_view>
+            <observers>
+                <update_layout_for_reverb_order>
+                    <type>singleton</type>
+                    <class>reverbSync/observer_orders</class>
+                    <method>updateAdminOrderViewForReverbOrderInvoices</method>
+                </update_layout_for_reverb_order>
+            </observers>
+        </controller_action_layout_render_before_adminhtml_sales_order_invoice_view>
     </events>
 
   </adminhtml>

--- a/app/design/adminhtml/default/default/template/ReverbSync/sales/order/view/info.phtml
+++ b/app/design/adminhtml/default/default/template/ReverbSync/sales/order/view/info.phtml
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    design
+ * @package     default_default
+ * @copyright   Copyright (c) 2006-2015 X.commerce, Inc. (http://www.magento.com)
+ * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+?>
+<?php $_order = $this->getOrder() ?>
+<?php
+$orderAdminDate = $this->formatDate($_order->getCreatedAtDate(), 'medium', true);
+$orderStoreDate = $this->formatDate($_order->getCreatedAtStoreDate(), 'medium', true);
+?>
+<div class="box-left">
+    <!--Order Information-->
+    <div class="entry-edit">
+        <?php if ($_order->getEmailSent()):
+            $_email = Mage::helper('sales')->__('the order confirmation email was sent');
+        else:
+            $_email = Mage::helper('sales')->__('the order confirmation email is not sent');
+        endif; ?>
+        <div class="entry-edit-head">
+        <?php if ($this->getNoUseOrderLink()): ?>
+            <h4 class="icon-head head-account"><?php echo Mage::helper('sales')->__('Order # %s', $_order->getRealOrderId()) ?> (<?php echo $_email ?>)</h4>
+        <?php else: ?>
+            <a href="<?php echo $this->getViewUrl($_order->getId()) ?>"><?php echo Mage::helper('sales')->__('Order # %s', $_order->getRealOrderId()) ?></a>
+            <strong>(<?php echo $_email ?>)</strong>
+        <?php endif; ?>
+        </div>
+        <div class="fieldset">
+            <table cellspacing="0" class="form-list">
+            <tr>
+                <td class="label"><label><?php echo Mage::helper('sales')->__('Order Date') ?></label></td>
+                <td class="value"><strong><?php echo $orderAdminDate ?></strong></td>
+            </tr>
+            <?php if ($orderAdminDate != $orderStoreDate):?>
+            <tr>
+                <td class="label"><label><?php echo Mage::helper('sales')->__('Order Date (%s)', $_order->getCreatedAtStoreDate()->getTimezone()) ?></label></td>
+                <td class="value"><strong><?php echo $orderStoreDate ?></strong></td>
+            </tr>
+            <?php endif;?>
+            <tr>
+                <td class="label"><label><?php echo Mage::helper('sales')->__('Order Status') ?></label></td>
+                <td class="value"><strong><span id="order_status"><?php echo $_order->getStatusLabel() ?></span></strong></td>
+            </tr>
+            <tr>
+                <td class="label"><label><?php echo Mage::helper('sales')->__('Purchased From') ?></label></td>
+                <td class="value"><strong><?php echo Mage::helper('ReverbSync/orders_view')->getStoreNameForReverbOrder($this->getOrder()) ?></strong></td>
+            </tr>
+            <tr>
+                <td class="label"><label><?php echo Mage::helper('sales')->__('Reverb Order ID') ?></label></td>
+                <td class="value"><strong><?php echo Mage::helper('ReverbSync/orders_view')->getReverbOrderId($this->getOrder()) ?></strong></td>
+            </tr>
+            <tr>
+                <td class="label"><label><?php echo Mage::helper('sales')->__('Reverb Order Status') ?></label></td>
+                <td class="value"><strong><?php echo Mage::helper('ReverbSync/orders_view')->getReverbOrderStatus($this->getOrder()) ?></strong></td>
+            </tr>
+            <?php if($_order->getRelationChildId()): ?>
+            <tr>
+                <td class="label"><label><?php echo Mage::helper('sales')->__('Link to the New Order') ?></label></td>
+                <td class="value"><a href="<?php echo $this->getViewUrl($_order->getRelationChildId()) ?>">
+                    <?php echo $_order->getRelationChildRealId() ?>
+                </a></td>
+            </tr>
+            <?php endif; ?>
+            <?php if($_order->getRelationParentId()): ?>
+            <tr>
+                <td class="label"><label><?php echo Mage::helper('sales')->__('Link to the Previous Order') ?></label></td>
+                <td class="value"><a href="<?php echo $this->getViewUrl($_order->getRelationParentId()) ?>">
+                    <?php echo $_order->getRelationParentRealId() ?>
+                </a></td>
+            </tr>
+            <?php endif; ?>
+            <?php if($_order->getRemoteIp() && $this->shouldDisplayCustomerIp()): ?>
+            <tr>
+                <td class="label"><label><?php echo Mage::helper('sales')->__('Placed from IP') ?></label></td>
+                <td class="value"><strong><?php echo $_order->getRemoteIp(); echo ($_order->getXForwardedFor())?' (' . $this->escapeHtml($_order->getXForwardedFor()) . ')':''; ?></strong></td>
+            </tr>
+            <?php endif; ?>
+            <?php if($_order->getGlobalCurrencyCode() != $_order->getBaseCurrencyCode()): ?>
+            <tr>
+                <td class="label"><label><?php echo Mage::helper('sales')->__('%s / %s rate:', $_order->getGlobalCurrencyCode(), $_order->getBaseCurrencyCode()) ?></label></td>
+                <td class="value"><strong><?php echo $_order->getBaseToGlobalRate() ?></strong></td>
+            </tr>
+            <?php endif; ?>
+            <?php if($_order->getBaseCurrencyCode() != $_order->getOrderCurrencyCode()): ?>
+            <tr>
+                <td class="label"><label><?php echo Mage::helper('sales')->__('%s / %s rate:', $_order->getOrderCurrencyCode(), $_order->getBaseCurrencyCode()) ?></label></td>
+                <td class="value"><strong><?php echo $_order->getBaseToOrderRate() ?></strong></td>
+            </tr>
+            <?php endif; ?>
+            </table>
+        </div>
+    </div>
+</div>
+<div class="box-right">
+    <!--Account Information-->
+    <div class="entry-edit">
+        <div class="entry-edit-head">
+            <h4 class="icon-head head-account"><?php echo Mage::helper('sales')->__('Account Information') ?></h4>
+            <div class="tools"><?php echo $this->getAccountEditLink()?></div>
+        </div>
+        <div class="fieldset">
+            <div class="hor-scroll">
+                <table cellspacing="0" class="form-list">
+                <tr>
+                    <td class="label"><label><?php echo Mage::helper('sales')->__('Customer Name') ?></label></td>
+                    <td class="value">
+                    <?php if ($_customerUrl=$this->getCustomerViewUrl()) : ?>
+                        <a href="<?php echo $_customerUrl ?>" target="_blank"><strong><?php echo $this->escapeHtml($_order->getCustomerName()) ?></strong></a>
+                    <?php else: ?>
+                        <strong><?php echo $this->escapeHtml($_order->getCustomerName()) ?></strong>
+                    <?php endif; ?>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="label"><label><?php echo Mage::helper('sales')->__('Email') ?></label></td>
+                    <td class="value"><a href="mailto:<?php echo $_order->getCustomerEmail() ?>"><strong><?php echo $_order->getCustomerEmail() ?></strong></a></td>
+                </tr>
+                <?php if ($_groupName = $this->getCustomerGroupName()) : ?>
+                <tr>
+                    <td class="label"><label><?php echo Mage::helper('sales')->__('Customer Group') ?></label></td>
+                    <td class="value"><strong><?php echo $_groupName ?></strong></td>
+                </tr>
+                <?php endif; ?>
+                <?php foreach ($this->getCustomerAccountData() as $data):?>
+                <tr>
+                    <td class="label"><label><?php echo $data['label'] ?></label></td>
+                    <td class="value"><strong><?php echo $data['value'] ?></strong></td>
+                </tr>
+                <?php endforeach;?>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="clear"></div>
+
+<div class="box-left">
+    <!--Billing Address-->
+    <div class="entry-edit">
+        <div class="entry-edit-head">
+            <h4 class="icon-head head-billing-address"><?php echo Mage::helper('sales')->__('Billing Address') ?></h4>
+            <div class="tools"><?php echo $this->getAddressEditLink($_order->getBillingAddress())?></div>
+        </div>
+        <fieldset>
+            <address><?php echo $_order->getBillingAddress()->getFormated(true) ?></address>
+        </fieldset>
+    </div>
+</div>
+<?php if (!$this->getOrder()->getIsVirtual()): ?>
+<div class="box-right">
+    <!--Shipping Address-->
+    <div class="entry-edit">
+        <div class="entry-edit-head">
+            <h4 class="icon-head head-shipping-address"><?php echo Mage::helper('sales')->__('Shipping Address') ?></h4>
+            <div class="tools"><?php echo $this->getAddressEditLink($_order->getShippingAddress())?></div>
+        </div>
+        <fieldset>
+            <address><?php echo $_order->getShippingAddress()->getFormated(true) ?></address>
+        </fieldset>
+    </div>
+</div>
+<div class="clear"></div>
+<?php endif; ?>


### PR DESCRIPTION
Fix #71 Fix #72 

I originally added the Reverb Order ID and Status on a separate tab because it required a less invasive approach that updating the main order view template. However #72  required me to update that template, so I went ahead and added the Order ID and status right below the store name. Let me know if you want me to remove the tab as a result