### PR TITLE
Preventing failed lock attempts from logging errors for listing sync.…

### DIFF
--- a/app/code/community/Reverb/Process/Model/Locked/Cron/Abstract.php
+++ b/app/code/community/Reverb/Process/Model/Locked/Cron/Abstract.php
@@ -16,6 +16,8 @@ abstract class Reverb_Process_Model_Locked_Cron_Abstract
 
     abstract public function attemptLockForThread($thread_number);
 
+    protected $_suppress_failed_lock_attempt_error_messages = false;
+
     public function attemptLock()
     {
         $thread_count = $this->getParallelThreadCount();
@@ -63,7 +65,10 @@ abstract class Reverb_Process_Model_Locked_Cron_Abstract
             $cron_code = $this->getCronCode();
             $error_message = sprintf(self::ERROR_UNABLE_TO_SECURE_LOCK_FILE, $cron_code);
 
-            $this->_logError($error_message);
+            if (!$this->_suppress_failed_lock_attempt_error_messages)
+            {
+                $this->_logError($error_message);
+            }
         }
     }
 }

--- a/app/code/community/Reverb/ReverbSync/Model/Cron/Listings/Sync.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Cron/Listings/Sync.php
@@ -10,6 +10,8 @@ class Reverb_ReverbSync_Model_Cron_Listings_Sync
 {
     const CRON_UNCAUGHT_EXCEPTION = 'Error processing the Reverb Listing Sync Process Queue: %s';
 
+    protected $_suppress_failed_lock_attempt_error_messages = true;
+
     public function executeCron()
     {
         try
@@ -43,5 +45,10 @@ class Reverb_ReverbSync_Model_Cron_Listings_Sync
     public function getCronCode()
     {
         return 'reverb_listing_sync';
+    }
+
+    protected function _logError($error_message)
+    {
+        Mage::getSingleton('reverbSync/log')->logListingSyncError($error_message);
     }
 } 

--- a/app/code/community/Reverb/ReverbSync/Model/Cron/Orders/Creation.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Cron/Orders/Creation.php
@@ -49,4 +49,9 @@ class Reverb_ReverbSync_Model_Cron_Orders_Creation
     {
         return 'reverb_order_creation';
     }
+
+    protected function _logError($error_message)
+    {
+        Mage::getSingleton('reverbSync/log')->logOrderSyncError($error_message);
+    }
 } 

--- a/app/code/community/Reverb/ReverbSync/Model/Cron/Orders/Retrieval.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Cron/Orders/Retrieval.php
@@ -55,4 +55,9 @@ class Reverb_ReverbSync_Model_Cron_Orders_Retrieval
     {
         return 'reverb_order_retrieval';
     }
+
+    protected function _logError($error_message)
+    {
+        Mage::getSingleton('reverbSync/log')->logOrderSyncError($error_message);
+    }
 }

--- a/app/code/community/Reverb/ReverbSync/Model/Cron/Orders/Update.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Cron/Orders/Update.php
@@ -49,4 +49,9 @@ class Reverb_ReverbSync_Model_Cron_Orders_Update
     {
         return 'reverb_order_update';
     }
+
+    protected function _logError($error_message)
+    {
+        Mage::getSingleton('reverbSync/log')->logOrderSyncError($error_message);
+    }
 }

--- a/app/code/community/Reverb/ReverbSync/Model/Log.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Log.php
@@ -21,6 +21,11 @@ class Reverb_ReverbSync_Model_Log
         $this->logSyncError($error_message, 'orders');
     }
 
+    public function logListingSyncError($error_message)
+    {
+        $this->logSyncError($error_message, 'listings');
+    }
+
     public function logSyncError($error_message, $sync_process = null)
     {
         if (is_null($sync_process))


### PR DESCRIPTION
Fix #86 

This was a quick one which will help us when debugging client issues, so I knocked it out quick