### PR TITLE
Renamed rev_sync attribute to sync_to_reverb for clarity [Fix #115]

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Helper/Sync/Product.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Sync/Product.php
@@ -91,7 +91,7 @@ class Reverb_ReverbSync_Helper_Sync_Product extends Mage_Core_Helper_Data
 
     protected function _productIsExcludedFromSync($product)
     {
-        $revSync = $product -> getRevSync();
+        $revSync = $product -> getSyncToReverb();
         if (is_null($revSync))
         {
             // Default functionality should be to sync product
@@ -131,4 +131,4 @@ class Reverb_ReverbSync_Helper_Sync_Product extends Mage_Core_Helper_Data
 
         return $this->_reverbAdminHelper;
     }
-} 
+}

--- a/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-install-0.1.0.php
+++ b/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-install-0.1.0.php
@@ -51,7 +51,7 @@ catch (Exception $excp)
     Mage::log($excp->getMessage());
 }
 try{
-    $setup->addAttribute(Mage_Catalog_Model_Product::ENTITY, 'rev_sync', array(
+    $setup->addAttribute(Mage_Catalog_Model_Product::ENTITY, 'sync_to_reverb', array(
         'group' => 'General',
         'type' => 'int',
         'backend' => '',

--- a/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.0-0.1.1.php
+++ b/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.0-0.1.1.php
@@ -7,7 +7,7 @@ $conn = $installer->getConnection();
 try
 {
     $setup = Mage::getModel('eav/entity_setup', 'core_setup');
-    $setup->updateAttribute(Mage_Catalog_Model_Product::ENTITY, 'rev_sync', 'default_value', 1);
+    $setup->updateAttribute(Mage_Catalog_Model_Product::ENTITY, 'sync_to_reverb', 'default_value', 1);
 }
 catch (Exception $excp)
 {


### PR DESCRIPTION
Renamed `rev_sync` attribute to `sync_to_reverb` and updated usages