### PR TITLE
Removed exception during Product Save, improved performance [Fix #121]

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Model/Observer.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Observer.php
@@ -9,15 +9,21 @@ class Reverb_ReverbSync_Model_Observer
     {
       try
       {
-        $productSyncHelper = Mage::helper('ReverbSync/sync_product');
-        $product_id = $observer->getProduct()->getId();
-          // TODO: This will generate one SQL query per product saved.  Revamp this to queue the check and process in batches.
-          $syncToReverb = Mage::getResourceModel('catalog/product')->getAttributeRawValue($product_id, 'rev_sync');
+          $product = $observer->getProduct();
+          $product_id = $product->getId();
+
+          $syncToReverb = $product->getData('rev_sync');
+          if (is_null($syncToReverb)) {
+              // TODO: This will potentially generate one SQL query per product saved.  Revamp this to queue the check and process in async batches.
+              $syncToReverb = Mage::getResourceModel('catalog/product')->getAttributeRawValue($product_id, 'rev_sync');
+          }
+
           if (!$syncToReverb) {
             // Sync To Reverb is disabled for this product
             return;
           }
 
+          $productSyncHelper = Mage::helper('ReverbSync/sync_product');
           $listingWrapper = $productSyncHelper->executeIndividualProductDataSync($product_id);
         }
         catch(Reverb_ReverbSync_Model_Exception_Product_Excluded $e)

--- a/app/code/community/Reverb/ReverbSync/Model/Observer.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Observer.php
@@ -7,11 +7,18 @@ class Reverb_ReverbSync_Model_Observer
     //function to create the product in reverb
     public function productSave($observer)
     {
+      try
+      {
         $productSyncHelper = Mage::helper('ReverbSync/sync_product');
         $product_id = $observer->getProduct()->getId();
-        try
-        {
-            $listingWrapper = $productSyncHelper->executeIndividualProductDataSync($product_id);
+          // TODO: This will generate one SQL query per product saved.  Revamp this to queue the check and process in batches.
+          $syncToReverb = Mage::getResourceModel('catalog/product')->getAttributeRawValue($product_id, 'rev_sync');
+          if (!$syncToReverb) {
+            // Sync To Reverb is disabled for this product
+            return;
+          }
+
+          $listingWrapper = $productSyncHelper->executeIndividualProductDataSync($product_id);
         }
         catch(Reverb_ReverbSync_Model_Exception_Product_Excluded $e)
         {


### PR DESCRIPTION
Product Save event handler now explicitly checks the value of the "Sync to Reverb" attribute and exits early.  This isn't ideal, as it generates one SQL query per product save event, however it should avoid a fair number of `$product->load()` calls which are currently a waste for products which are not sync'd to Reverb.

The proper fix would be to either ensure the Sync to Reverb attribute has been loaded on the product being saved (so that no extra queries are required) or to queue the product ID's for async batch processing.