### PR TITLE
Rename reverb attributes to use "reverb_" prefix instead of "rev_" [Fix #115]

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Catalog/Product/Tab.php
+++ b/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Catalog/Product/Tab.php
@@ -55,7 +55,7 @@ class Reverb_ReverbSync_Block_Adminhtml_Catalog_Product_Tab extends Mage_Adminht
         try {
             $productId = Mage::registry('current_product') -> getId();
             $targetProductId = Mage::getModel('catalog/product') -> load($productId);
-            $revProductId = $targetProductId -> getRevProductId();
+            $revProductId = $targetProductId -> getReverbProductId();
         } catch (Exception $e) {
             $excp = 'Message: ' . $e -> getMessage();
             Mage::log($excp);
@@ -66,7 +66,7 @@ class Reverb_ReverbSync_Block_Adminhtml_Catalog_Product_Tab extends Mage_Adminht
         try {
             $productId = Mage::registry('current_product') -> getId();
             $targetProductId = Mage::getModel('catalog/product') -> load($productId);
-            $revProductUrl = $targetProductId -> getRevProductUrl();
+            $revProductUrl = $targetProductId -> getReverbProductUrl();
         } catch (Exception $e) {
             $excp = 'Message: ' . $e -> getMessage();
             Mage::log($excp);

--- a/app/code/community/Reverb/ReverbSync/Helper/Sync/Product.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Sync/Product.php
@@ -47,7 +47,7 @@ class Reverb_ReverbSync_Helper_Sync_Product extends Mage_Core_Helper_Data
     public function getReverbSyncEligibleProductIds()
     {
         $products = Mage::getModel('catalog/product')->getCollection()
-            ->addFieldToFilter('rev_sync', true);
+            ->addFieldToFilter('reverb_sync_enabled', true);
         $ids = $products->getAllIds();
 
         return $ids;
@@ -70,7 +70,7 @@ class Reverb_ReverbSync_Helper_Sync_Product extends Mage_Core_Helper_Data
         if ($productType != 'simple') {
             throw new Reverb_ReverbSync_Model_Exception_Product_Excluded("Only simple products can be synced.");
         }
-        if (!$product->getRevSync())
+        if (!$product->getReverbSyncEnabled())
         {
             throw new Reverb_ReverbSync_Model_Exception_Product_Excluded(self::PRODUCT_EXCLUDED_FROM_SYNC);
         }

--- a/app/code/community/Reverb/ReverbSync/Model/Observer.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Observer.php
@@ -12,10 +12,10 @@ class Reverb_ReverbSync_Model_Observer
           $product = $observer->getProduct();
           $product_id = $product->getId();
 
-          $syncToReverb = $product->getData('rev_sync');
+          $syncToReverb = $product->getData('reverb_sync_enabled');
           if (is_null($syncToReverb)) {
               // TODO: This will potentially generate one SQL query per product saved.  Revamp this to queue the check and process in async batches.
-              $syncToReverb = Mage::getResourceModel('catalog/product')->getAttributeRawValue($product_id, 'rev_sync');
+              $syncToReverb = Mage::getResourceModel('catalog/product')->getAttributeRawValue($product_id, 'reverb_sync_enabled');
           }
 
           if (!$syncToReverb) {

--- a/app/code/community/Reverb/ReverbSync/etc/config.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
   <modules>
     <Reverb_ReverbSync>
-      <version>0.1.6</version>
+      <version>0.1.7</version>
     </Reverb_ReverbSync>
   </modules>
   <global>
@@ -19,6 +19,7 @@
       <reverbsync_setup>
         <setup>
           <module>Reverb_ReverbSync</module>
+          <class>Mage_Eav_Model_Entity_Setup</class>
         </setup>
         <connection>
           <use>core_setup</use>

--- a/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.6-0.1.7.php
+++ b/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.6-0.1.7.php
@@ -1,0 +1,15 @@
+<?php
+
+/** @var Mage_Eav_Model_Entity_Setup $installer */
+$installer = $this;
+
+$installer->startSetup();
+
+// Rename attributes to use "reverb_" prefix
+// TODO: Attributes could use friendlier labels - e.g. "Reverb.com Product Id" instead of "Rev Product id"
+$installer->updateAttribute(Mage_Catalog_Model_Product::ENTITY, 'rev_sync', array('attribute_code' => 'reverb_sync_enabled'));
+$installer->updateAttribute(Mage_Catalog_Model_Product::ENTITY, 'rev_product_id', array('attribute_code' => 'reverb_product_id'));
+$installer->updateAttribute(Mage_Catalog_Model_Product::ENTITY, 'rev_product_url', array('attribute_code' => 'reverb_product_Url'));
+
+$installer->endSetup();
+


### PR DESCRIPTION
Tested migration script against 0.4.4