### PR TITLE
Increases window of how far back we will go to fetch orders [Ref #160]

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Retrieval/Creation.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Retrieval/Creation.php
@@ -7,7 +7,7 @@
 class Reverb_ReverbSync_Helper_Orders_Retrieval_Creation
     extends Reverb_ReverbSync_Helper_Orders_Retrieval
 {
-    const MINUTES_IN_PAST_FOR_CREATION_QUERY = 1440;
+    const MINUTES_IN_PAST_FOR_CREATION_QUERY = 4320; # 3 days
     const EXCEPTION_CHECK_IF_ORDER_ALREADY_SYNCED = 'Error checking to see if order with reverb id %s had already been created in Magento: %s';
 
     public function queueOrderActionByReverbOrderDataObject(stdClass $orderDataObject)


### PR DESCRIPTION
This is a temporary "fix" for #160 where we occasionally fail to correctly
fetch orders. In both cases where this happened, increasing the sync window
seemed to recover the missing orders.

My guess is the underlying issue is a timezone mismatch or something related to
us not fetching far back enough if we've missed a few fetches.