### PR TITLE
Disable sync of categories on update until we fix the category mapper

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Model/Mapper/Product.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Mapper/Product.php
@@ -46,7 +46,13 @@ class Reverb_ReverbSync_Model_Mapper_Product
             $fieldsArray['inventory'] = $stock->getQty();
         }
 
-        $this->addCategoryToFieldsArray($fieldsArray, $product);
+
+        // We are not syncing categories on update because the category sync is buggy
+        // and is sending over top level categories in the "categories" field, which should
+        // be subcategories. Until that is fixed, we have taken out this call:
+        //
+        // $this->addCategoryToFieldsArray($fieldsArray, $product);
+
         $this->addProductConditionIfSet($fieldsArray, $product);
 
         $reverbListingWrapper->setApiCallContentData($fieldsArray);

--- a/app/code/community/Reverb/ReverbSync/Model/Source/Orderurl.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Source/Orderurl.php
@@ -9,7 +9,7 @@ class Reverb_ReverbSync_Model_Source_Orderurl
     const ALL_ORDERS_URL = '/api/my/orders/selling/all?created_start_date=%s';
     const ALL_ORDERS_LABEL = 'All (including Unpaid Accepted Offers)';
 
-    // Not for awaiting shipment, we are using the updated timestamp because
+    // Note: for awaiting shipment, we are using the updated timestamp because
     // Orders may be created at time X but be awaiting shipment at X+Y.
     //
     // Thus it is safer to use the updated timestamp to make sure we don't miss any that were created


### PR DESCRIPTION
This PR stops syncing categories on update as there appears to be a bug where we are sending the top level category in the "categories" field. See also: #164 