### PR TITLE
Issues/GitHub 164

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Helper/Sync/Category.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Sync/Category.php
@@ -69,30 +69,62 @@ class Reverb_ReverbSync_Helper_Sync_Category extends Mage_Core_Helper_Abstract
             return $fieldsArray;
         }
 
-        $category_slug_array = array();
-        $product_type_slug = null;
+        $sorted_reverb_categories_desc = $this->sortReverbCategoriesByLevelDescending($product_reverb_category_objects_array);
+        // Get the deepest category
+        $deepestReverbCategory = array_shift($sorted_reverb_categories_desc);
+        $product_type_slug = $deepestReverbCategory->getData('reverb_product_type_slug');
+        $category_slug = $deepestReverbCategory->getData('reverb_category_slug');
 
-        foreach($product_reverb_category_objects_array as $reverbCategory)
+        // If the only categories mapped are top-level Reverb categories, there will be no category slug
+        if (!empty($category_slug))
         {
-            $category_slug_array[] = $reverbCategory->getReverbCategorySlug();
-            if (empty($product_type_slug))
-            {
-                $product_type_slug = $reverbCategory->getReverbProductTypeSlug();
-            }
+            $fieldsArray[self::CATEGORY_FIELD_NAME] = array($category_slug);
         }
-
-        // We expect category slug to be populated, but check just in case
-        if (!empty($category_slug_array))
-        {
-            $fieldsArray[self::CATEGORY_FIELD_NAME] = $category_slug_array;
-        }
-        // If the only categories mapped are top-level Reverb categories, there will be no product type slug
+        // We expect product type slug to be populated, but check just in case
         if (!empty($product_type_slug))
         {
             $fieldsArray[self::PRODUCT_TYPE_FIELD_NAME] = $product_type_slug;
         }
 
+        // See if there is a second category to be mapped to
+        if (!empty($sorted_reverb_categories_desc))
+        {
+            $secondDeepestReverbCategory = array_shift($sorted_reverb_categories_desc);
+            $second_category_slug = $secondDeepestReverbCategory->getData('reverb_category_slug');
+            if (!empty($second_category_slug))
+            {
+                if (isset($fieldsArray[self::CATEGORY_FIELD_NAME]) && is_array($fieldsArray[self::CATEGORY_FIELD_NAME]))
+                {
+                    $fieldsArray[self::CATEGORY_FIELD_NAME][] = $second_category_slug;
+                }
+                else
+                {
+                    // We shouldn't reach this point, but account for the case where we do
+                    $fieldsArray[self::CATEGORY_FIELD_NAME] = array($second_category_slug);
+                }
+            }
+        }
+
         return $fieldsArray;
+    }
+
+    public function sortReverbCategoriesByLevelDescending(array $product_reverb_category_objects_array)
+    {
+        usort($product_reverb_category_objects_array, 'Reverb_ReverbSync_Helper_Sync_Category::compareReverbCategoryLevelDescending');
+        return $product_reverb_category_objects_array;
+    }
+
+    static public function compareReverbCategoryLevelDescending($reverbCategoryA, $reverbCategoryB)
+    {
+        $category_name_a = $reverbCategoryA->getName();
+        $categories_in_hierarchy_a = explode(' > ', $category_name_a);
+        $category_a_levels = count($categories_in_hierarchy_a);
+
+        $category_name_b = $reverbCategoryB->getName();
+        $categories_in_hierarchy_b = explode(' > ', $category_name_b);
+        $category_b_levels = count($categories_in_hierarchy_b);
+
+        return ($category_a_levels < $category_b_levels);
     }
 
     public function getReverbCategoryObjectsByProduct(Mage_Catalog_Model_Product $magentoProduct)

--- a/app/code/community/Reverb/ReverbSync/Model/Mapper/Product.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Mapper/Product.php
@@ -46,12 +46,7 @@ class Reverb_ReverbSync_Model_Mapper_Product
             $fieldsArray['inventory'] = $stock->getQty();
         }
 
-
-        // We are not syncing categories on update because the category sync is buggy
-        // and is sending over top level categories in the "categories" field, which should
-        // be subcategories. Until that is fixed, we have taken out this call:
-        //
-        // $this->addCategoryToFieldsArray($fieldsArray, $product);
+        $this->addCategoryToFieldsArray($fieldsArray, $product);
 
         $this->addProductConditionIfSet($fieldsArray, $product);
 

--- a/app/code/community/Reverb/ReverbSync/Model/Mysql4/Category/Reverb.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Mysql4/Category/Reverb.php
@@ -7,7 +7,7 @@
 class Reverb_ReverbSync_Model_Mysql4_Category_Reverb extends Mage_Core_Model_Mysql4_Abstract
 {
     protected $_database_insert_columns_array
-                = array('name', 'description', 'reverb_product_type_slug', 'reverb_category_slug');
+                = array('name', 'description', 'reverb_category_slug', 'reverb_product_type_slug');
 
     public function _construct()
     {

--- a/app/code/community/Reverb/ReverbSync/etc/config.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
   <modules>
     <Reverb_ReverbSync>
-      <version>0.1.10</version>
+      <version>0.1.11</version>
     </Reverb_ReverbSync>
   </modules>
   <global>

--- a/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.10-0.1.11.php
+++ b/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.10-0.1.11.php
@@ -1,0 +1,8 @@
+<?php
+
+$installer = $this;
+$installer->startSetup();
+
+Mage::getResourceSingleton('reverbSync/category_reverb')->initializeReverbCategoriesTable();
+
+$installer->endSetup();


### PR DESCRIPTION
Fix #164 

The most recent issue (the Pro-Audio being sent in the wrong field) was in regards to the initial Reverb category population from the json. I have fixed that issue. 

Clients who have already mapped categories will need to re-map the categories unfortunately. If this is a major issue, I can update the upgrade script to repopulate the mapping for them, this would probably take an hour or two. Let me know if you want me to go ahead with that