### PR TITLE
Issues/GitHub 171

### DIFF
--- a/app/code/community/Reverb/Base/Block/Adminhtml/Widget/Grid/Container.php
+++ b/app/code/community/Reverb/Base/Block/Adminhtml/Widget/Grid/Container.php
@@ -49,7 +49,10 @@ class Reverb_Base_Block_Adminhtml_Widget_Grid_Container
 
     // OPTIONAL
 
-    // Subclass may override this class
+    // Subclass may override this method
+    /**
+     * @return array
+     */
     public function getActionButtonsToRender()
     {
         return array();

--- a/app/code/community/Reverb/Base/Controller/Adminhtml/Abstract.php
+++ b/app/code/community/Reverb/Base/Controller/Adminhtml/Abstract.php
@@ -108,6 +108,12 @@ abstract class Reverb_Base_Controller_Adminhtml_Abstract
         return true;
     }
 
+    public function getUriPathForIndexAction($action)
+    {
+        $uri_path = sprintf('%s/%s/%s', $this->getModuleRouterFrontname(), $this->getIndexActionsController(), $action);
+        return $uri_path;
+    }
+
     public function getAclPath()
     {
         return $this->getControllerActiveMenuPath();

--- a/app/code/community/Reverb/ProcessQueue/Block/Adminhtml/Task/Index.php
+++ b/app/code/community/Reverb/ProcessQueue/Block/Adminhtml/Task/Index.php
@@ -47,8 +47,10 @@ class Reverb_ProcessQueue_Block_Adminhtml_Task_Index
         }
         $encoded_redirect_route = urlencode($this->getRedirectRoute());
 
+        $clear_all_tasks_action = $this->getAction()->getUriPathForIndexAction('clearAllTasks');
+
         $clear_all_tasks_button = array(
-            'action_url' => Mage::getModel('adminhtml/url')->getUrl('adminhtml/ProcessQueue_index/clearAllTasks',
+            'action_url' => Mage::getModel('adminhtml/url')->getUrl($clear_all_tasks_action,
                                                                         array('task_codes' => $task_code_param,
                                                                         'redirect_route' => $encoded_redirect_route)
                                                                     ),
@@ -56,8 +58,9 @@ class Reverb_ProcessQueue_Block_Adminhtml_Task_Index
             'confirm_message' => 'Are you sure you want to clear all tasks?'
         );
 
+        $clear_successful_tasks_action = $this->getAction()->getUriPathForIndexAction('clearSuccessfulTasks');
         $clear_successful_tasks_button = array(
-            'action_url' => Mage::getModel('adminhtml/url')->getUrl('adminhtml/ProcessQueue_index/clearSuccessfulTasks',
+            'action_url' => Mage::getModel('adminhtml/url')->getUrl($clear_successful_tasks_action,
                                                                         array('task_codes' => $task_code_param,
                                                                         'redirect_route' => $encoded_redirect_route)
                                                                     ),

--- a/app/code/community/Reverb/ProcessQueue/Block/Adminhtml/Task/Index.php
+++ b/app/code/community/Reverb/ProcessQueue/Block/Adminhtml/Task/Index.php
@@ -7,6 +7,8 @@
 class Reverb_ProcessQueue_Block_Adminhtml_Task_Index
     extends Reverb_Base_Block_Adminhtml_Widget_Grid_Container
 {
+    const BUTTON_ACTION_TEMPLATE = "confirmSetLocation('%s', '%s')";
+
     /**
      * Should return the task job codes for this page
      *
@@ -22,9 +24,16 @@ class Reverb_ProcessQueue_Block_Adminhtml_Task_Index
         return $this->getAction()->getFullBackControllerActionPath();
     }
 
-    public function getActionButtonsToRender()
+    public function __construct()
     {
-        $buttons_to_render = parent::getActionButtonsToRender();
+        parent::__construct();
+
+        $this->_addClearTasksButtons();
+    }
+
+    public function _addClearTasksButtons()
+    {
+        $buttons_to_render = array();
 
         $task_codes = $this->getTaskJobCodes();
         if (is_array($task_codes) && (!empty($task_codes)))
@@ -43,7 +52,8 @@ class Reverb_ProcessQueue_Block_Adminhtml_Task_Index
                                                                         array('task_codes' => $task_code_param,
                                                                         'redirect_route' => $encoded_redirect_route)
                                                                     ),
-            'label' => 'Clear All Tasks'
+            'label' => 'Clear All Tasks',
+            'confirm_message' => 'Are you sure you want to clear all tasks?'
         );
 
         $clear_successful_tasks_button = array(
@@ -51,12 +61,27 @@ class Reverb_ProcessQueue_Block_Adminhtml_Task_Index
                                                                         array('task_codes' => $task_code_param,
                                                                         'redirect_route' => $encoded_redirect_route)
                                                                     ),
-            'label' => 'Clear Successful Sync Tasks'
+            'label' => 'Clear Successful Sync Tasks',
+            'confirm_message' => 'Are you sure you want to clear all successful tasks?'
         );
 
         $buttons_to_render['clear_all_sync_tasks'] = $clear_all_tasks_button;
         $buttons_to_render['clear_successful_sync_tasks'] = $clear_successful_tasks_button;
 
-        return $buttons_to_render;
+        foreach ($buttons_to_render as $button_id => $button)
+        {
+            $label = $this->getAction()->getModuleHelper()->__($button['label']);
+            $confirm_message = $this->getAction()->getModuleHelper()->__($button['confirm_message']);
+            $action_url = $button['action_url'];
+            $onclick = sprintf(self::BUTTON_ACTION_TEMPLATE, $confirm_message, $action_url);
+
+            $this->_addButton(
+                $button_id, array(
+                    'label' => $this->getAction()->getModuleHelper()->__($label),
+                    'onclick' => $onclick,
+                    'level' => -1
+                )
+            );
+        }
     }
 }

--- a/app/code/community/Reverb/ProcessQueue/Block/Adminhtml/Task/Index.php
+++ b/app/code/community/Reverb/ProcessQueue/Block/Adminhtml/Task/Index.php
@@ -7,5 +7,56 @@
 class Reverb_ProcessQueue_Block_Adminhtml_Task_Index
     extends Reverb_Base_Block_Adminhtml_Widget_Grid_Container
 {
+    /**
+     * Should return the task job codes for this page
+     *
+     * @return string
+     */
+    public function getTaskJobCodes()
+    {
+        return null;
+    }
 
+    public function getRedirectRoute()
+    {
+        return $this->getAction()->getFullBackControllerActionPath();
+    }
+
+    public function getActionButtonsToRender()
+    {
+        $buttons_to_render = parent::getActionButtonsToRender();
+
+        $task_codes = $this->getTaskJobCodes();
+        if (is_array($task_codes) && (!empty($task_codes)))
+        {
+            $imploded_task_codes = implode(';', $task_codes);
+            $task_code_param = urlencode($imploded_task_codes);
+        }
+        else
+        {
+            $task_code_param = null;
+        }
+        $encoded_redirect_route = urlencode($this->getRedirectRoute());
+
+        $clear_all_tasks_button = array(
+            'action_url' => Mage::getModel('adminhtml/url')->getUrl('adminhtml/ProcessQueue_index/clearAllTasks',
+                                                                        array('task_codes' => $task_code_param,
+                                                                        'redirect_route' => $encoded_redirect_route)
+                                                                    ),
+            'label' => 'Clear All Tasks'
+        );
+
+        $clear_successful_tasks_button = array(
+            'action_url' => Mage::getModel('adminhtml/url')->getUrl('adminhtml/ProcessQueue_index/clearSuccessfulTasks',
+                                                                        array('task_codes' => $task_code_param,
+                                                                        'redirect_route' => $encoded_redirect_route)
+                                                                    ),
+            'label' => 'Clear Successful Sync Tasks'
+        );
+
+        $buttons_to_render['clear_all_sync_tasks'] = $clear_all_tasks_button;
+        $buttons_to_render['clear_successful_sync_tasks'] = $clear_successful_tasks_button;
+
+        return $buttons_to_render;
+    }
 }

--- a/app/code/community/Reverb/ProcessQueue/Helper/Task.php
+++ b/app/code/community/Reverb/ProcessQueue/Helper/Task.php
@@ -22,7 +22,9 @@ class Reverb_ProcessQueue_Helper_Task extends Mage_Core_Helper_Data
 
         $rows_deleted = Mage::getResourceSingleton('reverb_process_queue/task')
                             ->deleteSuccessfulTasks($task_code, $stale_date);
+        $unique_rows_deleted = Mage::getResourceSingleton('reverb_process_queue/task_unique')
+                                ->deleteSuccessfulTasks($task_code, $stale_date);
 
-        return $rows_deleted;
+        return ($rows_deleted + $unique_rows_deleted);
     }
 }

--- a/app/code/community/Reverb/ProcessQueue/Helper/Task.php
+++ b/app/code/community/Reverb/ProcessQueue/Helper/Task.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Author: Sean Dunagan (https://github.com/dunagan5887)
+ * Created: 12/9/15
+ */
+
+class Reverb_ProcessQueue_Helper_Task extends Mage_Core_Helper_Data
+{
+    const STALE_TIME_LAPSE = '-2 weeks';
+
+    /**
+     * The calling block is expected to catch exceptions
+     *
+     * @param null|string $task_code
+     * @return int - Number of rows deleted
+     */
+    public function deleteStaleSuccessfulTasks($task_code = null)
+    {
+        $current_gmt_timestamp = Mage::getSingleton('core/date')->gmtTimestamp();
+        $stale_timestamp = strtotime(self::STALE_TIME_LAPSE, $current_gmt_timestamp);
+        $stale_date = date('Y-m-d H:i:s', $stale_timestamp);
+
+        $rows_deleted = Mage::getResourceSingleton('reverb_process_queue/task')
+                            ->deleteSuccessfulTasks($task_code, $stale_date);
+
+        return $rows_deleted;
+    }
+}

--- a/app/code/community/Reverb/ProcessQueue/Helper/Task/Processor.php
+++ b/app/code/community/Reverb/ProcessQueue/Helper/Task/Processor.php
@@ -16,6 +16,7 @@ class Reverb_ProcessQueue_Helper_Task_Processor extends Mage_Core_Helper_Data
 
     protected $_moduleName = 'reverb_process_queue';
     protected $_task_model_classname = 'reverb_process_queue/task';
+    protected $_taskResourceSingleton = null;
     protected $_logModel = null;
 
     // TODO Refactor this
@@ -197,9 +198,31 @@ class Reverb_ProcessQueue_Helper_Task_Processor extends Mage_Core_Helper_Data
         return $rows_updated;
     }
 
+    public function deleteAllTasks($task_codes)
+    {
+        $rows_deleted = $this->_getTaskResourceSingleton()->deleteAllTasks($task_codes);
+        return $rows_deleted;
+    }
+
+    public function deleteSuccessfulTasks($task_codes)
+    {
+        $rows_deleted = $this->_getTaskResourceSingleton()->deleteSuccessfulTasks($task_codes);
+        return $rows_deleted;
+    }
+
     protected function _getTaskCollectionModel()
     {
         return Mage::getModel($this->_task_model_classname)->getCollection();
+    }
+
+    protected function _getTaskResourceSingleton()
+    {
+        if (is_null($this->_taskResourceSingleton))
+        {
+            $this->_taskResourceSingleton = Mage::getResourceSingleton($this->_task_model_classname);
+        }
+
+        return $this->_taskResourceSingleton;
     }
 
     protected function _logError($error_message)

--- a/app/code/community/Reverb/ProcessQueue/Model/Cron/Delete/Stale/Successful.php
+++ b/app/code/community/Reverb/ProcessQueue/Model/Cron/Delete/Stale/Successful.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Author: Sean Dunagan (https://github.com/dunagan5887)
+ * Created: 12/9/15
+ */
+
+class Reverb_ProcessQueue_Model_Cron_Delete_Stale_Successful
+{
+    const CRON_UNCAUGHT_EXCEPTION = 'Error deleting stale success tasks from the Reverb Process Queue: %s';
+
+    public function deleteStaleSuccessfulQueueTasks()
+    {
+        try
+        {
+            Mage::helper('reverb_process_queue/task')->deleteStaleSuccessfulTasks();
+        }
+        catch(Exception $e)
+        {
+            $error_message = sprintf(self::CRON_UNCAUGHT_EXCEPTION, $e->getMessage());
+            Mage::log($error_message, null, 'reverb_process_queue_error.log');
+            $exceptionToLog = new Exception($error_message);
+            Mage::logException($exceptionToLog);
+        }
+    }
+}

--- a/app/code/community/Reverb/ProcessQueue/Model/Mysql4/Task.php
+++ b/app/code/community/Reverb/ProcessQueue/Model/Mysql4/Task.php
@@ -90,6 +90,49 @@ class Reverb_ProcessQueue_Model_Mysql4_Task extends Mage_Core_Model_Mysql4_Abstr
         return 0;
     }
 
+    /**
+     * @param null|string|array $task_code
+     * @param null|string $last_executed_date - Expected to be a date in 'Y-m-d H:i:s' format
+     * @return int - Number of rows deleted
+     */
+    public function deleteSuccessfulTasks($task_code = null, $last_executed_date = null)
+    {
+        $where_condition_array = array('status=?' => Reverb_ProcessQueue_Model_Task::STATUS_COMPLETE);
+        if (!empty($task_code))
+        {
+            if (!is_array($task_code))
+            {
+                $task_code = array($task_code);
+            }
+            $where_condition_array['code in (?)'] = $task_code;
+        }
+        if (!empty($last_executed_date))
+        {
+            $where_condition_array['last_executed_at < ?'] = $last_executed_date;
+        }
+        $rows_deleted = $this->_getWriteAdapter()->delete($this->getMainTable(), $where_condition_array);
+        return $rows_deleted;
+    }
+
+    public function deleteAllTasks($task_code = null)
+    {
+        if(!empty($task_code))
+        {
+            if (!is_array($task_code))
+            {
+                $task_code = array($task_code);
+            }
+            $where_condition_array = array('code in (?)' => $task_code);
+            $rows_deleted = $this->_getWriteAdapter()->delete($this->getMainTable(), $where_condition_array);
+        }
+        else
+        {
+            $rows_deleted = $this->_getWriteAdapter()->delete($this->getMainTable());
+        }
+
+        return $rows_deleted;
+    }
+
     public function setTaskAsCompleted(Reverb_ProcessQueue_Model_Task_Interface $taskObject, $success_message = null)
     {
         return $this->setExecutionStatusForTask(Reverb_ProcessQueue_Model_Task::STATUS_COMPLETE, $taskObject, $success_message);

--- a/app/code/community/Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/IndexController.php
+++ b/app/code/community/Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/IndexController.php
@@ -48,8 +48,7 @@ class Reverb_ProcessQueue_Adminhtml_ProcessQueue_IndexController
         $redirect_route = $this->getRequest()->getParam('redirect_route');
         try
         {
-            $rows_deleted = Mage::getResourceSingleton('reverb_process_queue/task')
-                                ->deleteAllTasks($task_codes);
+            $rows_deleted = $this->_getTaskProcessor()->deleteAllTasks($task_codes);
         }
         catch(Exception $e)
         {
@@ -78,8 +77,7 @@ class Reverb_ProcessQueue_Adminhtml_ProcessQueue_IndexController
         $redirect_route = $this->getRequest()->getParam('redirect_route');
         try
         {
-            $rows_deleted = Mage::getResourceSingleton('reverb_process_queue/task')
-                                ->deleteSuccessfulTasks($task_codes);
+            $rows_deleted = $this->_getTaskProcessor()->deleteSuccessfulTasks($task_codes);
         }
         catch(Exception $e)
         {
@@ -160,6 +158,11 @@ class Reverb_ProcessQueue_Adminhtml_ProcessQueue_IndexController
     public function getIndexActionsController()
     {
         return 'ProcessQueue_index';
+    }
+
+    protected function _getTaskProcessor()
+    {
+        return Mage::helper('reverb_process_queue/task_processor');
     }
 
     /**

--- a/app/code/community/Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/Unique/IndexController.php
+++ b/app/code/community/Reverb/ProcessQueue/controllers/Adminhtml/ProcessQueue/Unique/IndexController.php
@@ -9,6 +9,11 @@ class Reverb_ProcessQueue_Adminhtml_ProcessQueue_Unique_IndexController
     extends Reverb_ProcessQueue_Adminhtml_ProcessQueue_IndexController
     implements Reverb_Base_Controller_Adminhtml_Form_Interface
 {
+    protected function _getTaskProcessor()
+    {
+        return Mage::helper('reverb_process_queue/task_processor_unique');
+    }
+
     public function getControllerActiveMenuPath()
     {
         return 'system/reverb_process_queue_unique';

--- a/app/code/community/Reverb/ProcessQueue/etc/config.xml
+++ b/app/code/community/Reverb/ProcessQueue/etc/config.xml
@@ -48,4 +48,29 @@
             </reverb_process_queue_setup>
         </resources>
     </global>
+
+    <admin>
+        <routers>
+            <adminhtml>
+                <args>
+                    <modules>
+                        <reverb_process_queue after="Mage_Adminhtml">Reverb_ProcessQueue_Adminhtml</reverb_process_queue>
+                    </modules>
+                </args>
+            </adminhtml>
+        </routers>
+    </admin>
+
+    <crontab>
+        <jobs>
+            <reverb_process_queue_delete_stale_successful>
+                <schedule>
+                    <cron_expr>36 4 * * *</cron_expr>
+                </schedule>
+                <run>
+                    <model>reverb_process_queue/cron_delete_stale_successful::deleteStaleSuccessfulQueueTasks</model>
+                </run>
+            </reverb_process_queue_delete_stale_successful>
+        </jobs>
+    </crontab>
 </config>

--- a/app/code/community/Reverb/ProcessQueue/etc/config.xml
+++ b/app/code/community/Reverb/ProcessQueue/etc/config.xml
@@ -61,7 +61,6 @@
         </routers>
     </admin>
 
-    <!--
     <crontab>
         <jobs>
             <reverb_process_queue_delete_stale_successful>
@@ -74,5 +73,4 @@
             </reverb_process_queue_delete_stale_successful>
         </jobs>
     </crontab>
-    -->
 </config>

--- a/app/code/community/Reverb/ProcessQueue/etc/config.xml
+++ b/app/code/community/Reverb/ProcessQueue/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Reverb_ProcessQueue>
-            <version>0.0.5</version>
+            <version>0.0.6</version>
         </Reverb_ProcessQueue>
     </modules>
 
@@ -61,6 +61,7 @@
         </routers>
     </admin>
 
+    <!--
     <crontab>
         <jobs>
             <reverb_process_queue_delete_stale_successful>
@@ -73,4 +74,5 @@
             </reverb_process_queue_delete_stale_successful>
         </jobs>
     </crontab>
+    -->
 </config>

--- a/app/code/community/Reverb/ProcessQueue/sql/reverb_process_queue_setup/upgrade-0.0.5-0.0.6.php
+++ b/app/code/community/Reverb/ProcessQueue/sql/reverb_process_queue_setup/upgrade-0.0.5-0.0.6.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Author: Sean Dunagan
+ * Created: 8/13/15
+ */
+
+$installer = $this;
+
+$installer->startSetup();
+
+$task_table_name = $installer->getTable('reverb_process_queue/task');
+$unique_task_table_name = $installer->getTable('reverb_process_queue/task_unique');
+
+$index_fields_array = array('last_executed_at');
+
+$task_table_subject_id_index_name = $installer->getIdxName('reverb_process_queue/task', $index_fields_array);
+$unique_task_table_subject_id_index_name = $installer->getIdxName('reverb_process_queue/task_unique', $index_fields_array);
+
+$installer->getConnection()
+    ->addIndex($task_table_name, $task_table_subject_id_index_name,
+        $index_fields_array, Varien_Db_Adapter_Interface::INDEX_TYPE_INDEX);
+
+$installer->getConnection()
+    ->addIndex($unique_task_table_name, $unique_task_table_subject_id_index_name,
+        $index_fields_array, Varien_Db_Adapter_Interface::INDEX_TYPE_INDEX);
+
+$installer->endSetup();
+

--- a/app/code/community/Reverb/ProcessQueue/sql/reverb_process_queue_setup/upgrade-0.0.5-0.0.6.php
+++ b/app/code/community/Reverb/ProcessQueue/sql/reverb_process_queue_setup/upgrade-0.0.5-0.0.6.php
@@ -13,15 +13,15 @@ $unique_task_table_name = $installer->getTable('reverb_process_queue/task_unique
 
 $index_fields_array = array('last_executed_at');
 
-$task_table_subject_id_index_name = $installer->getIdxName('reverb_process_queue/task', $index_fields_array);
-$unique_task_table_subject_id_index_name = $installer->getIdxName('reverb_process_queue/task_unique', $index_fields_array);
+$task_table_last_executed_at_index_name = $installer->getIdxName('reverb_process_queue/task', $index_fields_array);
+$unique_task_table_last_executed_at_index_name = $installer->getIdxName('reverb_process_queue/task_unique', $index_fields_array);
 
 $installer->getConnection()
-    ->addIndex($task_table_name, $task_table_subject_id_index_name,
+    ->addIndex($task_table_name, $task_table_last_executed_at_index_name,
         $index_fields_array, Varien_Db_Adapter_Interface::INDEX_TYPE_INDEX);
 
 $installer->getConnection()
-    ->addIndex($unique_task_table_name, $unique_task_table_subject_id_index_name,
+    ->addIndex($unique_task_table_name, $unique_task_table_last_executed_at_index_name,
         $index_fields_array, Varien_Db_Adapter_Interface::INDEX_TYPE_INDEX);
 
 $installer->endSetup();

--- a/app/code/community/Reverb/Reports/Model/Cron/Delete/Stale/Successful.php
+++ b/app/code/community/Reverb/Reports/Model/Cron/Delete/Stale/Successful.php
@@ -4,16 +4,15 @@
  * Created: 12/9/15
  */
 
-class Reverb_ProcessQueue_Model_Cron_Delete_Stale_Successful
+class Reverb_Reports_Model_Cron_Delete_Stale_Successful
 {
-    const CRON_UNCAUGHT_EXCEPTION = 'Error deleting stale success tasks from the Reverb Process Queue: %s';
+    const CRON_UNCAUGHT_EXCEPTION = 'Error deleting stale success reports from the Reverb Reports Table: %s';
 
-    public function deleteStaleSuccessfulQueueTasks()
+    public function deleteStaleSuccessfulReports()
     {
         try
         {
-            Mage::helper('reverb_process_queue/task')->deleteStaleSuccessfulTasks();
-
+            Mage::getResourceSingleton('reverb_reports/Reverbreport')->deleteStaleSuccessfulReports();
         }
         catch(Exception $e)
         {

--- a/app/code/community/Reverb/Reports/Model/Resource/Reverbreport.php
+++ b/app/code/community/Reverb/Reports/Model/Resource/Reverbreport.php
@@ -9,6 +9,9 @@
  */
 class Reverb_Reports_Model_Resource_Reverbreport
 extends Mage_Core_Model_Resource_Db_Abstract {
+
+    const STALE_TIME_LAPSE = '-2 weeks';
+
   /**
    * constructor
    * @access public
@@ -16,6 +19,17 @@ extends Mage_Core_Model_Resource_Db_Abstract {
   public function _construct() {
     $this -> _init('reverb_reports/reverbreport', 'entity_id');
   }
+
+    public function deleteStaleSuccessfulReports()
+    {
+        $current_gmt_timestamp = Mage::getSingleton('core/date')->gmtTimestamp();
+        $stale_timestamp = strtotime(self::STALE_TIME_LAPSE, $current_gmt_timestamp);
+        $stale_date = date('Y-m-d H:i:s', $stale_timestamp);
+
+        $where_condition_array = array('last_synced < ?' => $stale_date);
+        $rows_deleted = $this->_getWriteAdapter()->delete($this->getMainTable(), $where_condition_array);
+        return $rows_deleted;
+    }
 
     public function deleteAllReverbReportRows()
     {

--- a/app/code/community/Reverb/Reports/Model/Resource/Reverbreport.php
+++ b/app/code/community/Reverb/Reports/Model/Resource/Reverbreport.php
@@ -17,4 +17,16 @@ extends Mage_Core_Model_Resource_Db_Abstract {
     $this -> _init('reverb_reports/reverbreport', 'entity_id');
   }
 
+    public function deleteAllReverbReportRows()
+    {
+        $rows_deleted = $this->_getWriteAdapter()->delete($this->getMainTable());
+        return $rows_deleted;
+    }
+
+    public function deleteSuccessfulSyncs()
+    {
+        $where_condition_array = array('status=?' => Reverb_Reports_Model_Reverbreport::STATUS_SUCCESS);
+        $rows_deleted = $this->_getWriteAdapter()->delete($this->getMainTable(), $where_condition_array);
+        return $rows_deleted;
+    }
 }

--- a/app/code/community/Reverb/Reports/Model/Reverbreport.php
+++ b/app/code/community/Reverb/Reports/Model/Reverbreport.php
@@ -9,6 +9,8 @@
  */
 class Reverb_Reports_Model_Reverbreport extends Mage_Core_Model_Abstract
 {
+    const STATUS_SUCCESS = 1;
+
     // Table Field Name Constants
     const PRODUCT_ID_FIELD = 'product_id';
     const TITLE_FIELD = 'title';

--- a/app/code/community/Reverb/Reports/etc/config.xml
+++ b/app/code/community/Reverb/Reports/etc/config.xml
@@ -3,7 +3,7 @@
 <config>
     <modules>
         <Reverb_Reports>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </Reverb_Reports>
     </modules>
     <global>
@@ -81,4 +81,16 @@
             </adminhtml>
         </routers>
     </admin>
+    <crontab>
+        <jobs>
+            <reverb_reports_delete_stale_successful>
+                <schedule>
+                    <cron_expr>37 4 * * *</cron_expr>
+                </schedule>
+                <run>
+                    <model>reverb_reports/cron_delete_stale_successful::deleteStaleSuccessfulReports</model>
+                </run>
+            </reverb_reports_delete_stale_successful>
+        </jobs>
+    </crontab>
 </config>

--- a/app/code/community/Reverb/Reports/sql/reverb_reports_setup/upgrade-1.0.0-1.0.1.php
+++ b/app/code/community/Reverb/Reports/sql/reverb_reports_setup/upgrade-1.0.0-1.0.1.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Author: Sean Dunagan
+ * Created: 8/13/15
+ */
+
+$installer = $this;
+
+$installer->startSetup();
+
+$report_table_name = $installer->getTable('reverb_reports/reverbreport');
+
+$index_fields_array = array('last_synced');
+
+$reports_table_last_synced_index_name = $installer->getIdxName('reverb_process_queue/task', $index_fields_array);
+
+$installer->getConnection()
+    ->addIndex($report_table_name, $reports_table_last_synced_index_name,
+        $index_fields_array, Varien_Db_Adapter_Interface::INDEX_TYPE_INDEX);
+
+$installer->endSetup();
+

--- a/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Listings/Image/Task/Unique/Index.php
+++ b/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Listings/Image/Task/Unique/Index.php
@@ -7,6 +7,8 @@
 class Reverb_ReverbSync_Block_Adminhtml_Listings_Image_Task_Unique_Index
     extends Reverb_ProcessQueue_Block_Adminhtml_Task_Unique_Index
 {
+    const IMAGE_LISTING_SYNC_TASK_CODE = 'listing_image_sync';
+
     public function __construct()
     {
         $controllerAction = $this->getAction();
@@ -22,9 +24,14 @@ class Reverb_ReverbSync_Block_Adminhtml_Listings_Image_Task_Unique_Index
         $this->_blockGroup = $this->getAction()->getBlockModuleGroupname();
     }
 
+    public function getTaskJobCodes()
+    {
+        return array(self::IMAGE_LISTING_SYNC_TASK_CODE);
+    }
+
     public function getTaskCodeToFilterBy()
     {
-        return 'listing_image_sync';
+        return self::IMAGE_LISTING_SYNC_TASK_CODE;
     }
 
     protected function _expediteTasksButtonLabel()

--- a/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Listings/Index.php
+++ b/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Listings/Index.php
@@ -21,7 +21,19 @@ class Reverb_ReverbSync_Block_Adminhtml_Listings_Index extends Mage_Adminhtml_Bl
             'label' => 'Bulk Product Sync'
         );
 
+        $clear_all_tasks_button = array(
+            'action_url' => Mage::getModel('adminhtml/url')->getUrl('adminhtml/ReverbSync_listings_sync/clearAllTasks'),
+            'label' => 'Clear All Sync Tasks'
+        );
+
+        $clear_successful_tasks_button = array(
+            'action_url' => Mage::getModel('adminhtml/url')->getUrl('adminhtml/ReverbSync_listings_sync/clearSuccessfulTasks'),
+            'label' => 'Clear Successful Sync Tasks'
+        );
+
         $action_buttons_array['bulk_product_sync'] = $bulk_sync_process_button;
+        $action_buttons_array['clear_all_sync_tasks'] = $clear_all_tasks_button;
+        $action_buttons_array['clear_successful_sync_tasks'] = $clear_successful_tasks_button;
 
         foreach ($action_buttons_array as $button_id => $button_data)
         {

--- a/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Listings/Index/Syncing.php
+++ b/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Listings/Index/Syncing.php
@@ -19,6 +19,18 @@ class Reverb_ReverbSync_Block_Adminhtml_Listings_Index_Syncing extends Mage_Admi
             'label' => 'Stop Bulk Sync'
         );
 
+        $clear_all_tasks_button = array(
+            'action_url' => Mage::getModel('adminhtml/url')->getUrl('adminhtml/ReverbSync_listings_sync/clearAllTasks'),
+            'label' => 'Clear All Sync Tasks'
+        );
+
+        $clear_successful_tasks_button = array(
+            'action_url' => Mage::getModel('adminhtml/url')->getUrl('adminhtml/ReverbSync_listings_sync/clearSuccessfulTasks'),
+            'label' => 'Clear Successful Sync Tasks'
+        );
+
+        $action_buttons_array['clear_all_sync_tasks'] = $clear_all_tasks_button;
+        $action_buttons_array['clear_successful_sync_tasks'] = $clear_successful_tasks_button;
         $action_buttons_array['bulk_product_sync'] = $bulk_sync_process_button;
 
         foreach ($action_buttons_array as $button_id => $button_data)

--- a/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Orders/Task/Index.php
+++ b/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Orders/Task/Index.php
@@ -15,4 +15,9 @@ class Reverb_ReverbSync_Block_Adminhtml_Orders_Task_Index
 
         $this->removeButton('add');
     }
+
+    public function getTaskJobCodes()
+    {
+        return array('order_update');
+    }
 } 

--- a/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Orders/Task/Unique/Index.php
+++ b/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Orders/Task/Unique/Index.php
@@ -7,4 +7,8 @@
 class Reverb_ReverbSync_Block_Adminhtml_Orders_Task_Unique_Index
     extends Reverb_ReverbSync_Block_Adminhtml_Orders_Task_Index
 {
+    public function getTaskJobCodes()
+    {
+        return array('order_creation', Reverb_ReverbSync_Model_Sync_Shipment_Tracking::JOB_CODE);
+    }
 }

--- a/app/code/community/Reverb/ReverbSync/Helper/Sync/Product.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Sync/Product.php
@@ -86,6 +86,12 @@ class Reverb_ReverbSync_Helper_Sync_Product extends Mage_Core_Helper_Data
         return $resourceSingleton->deleteAllListingSyncTasks();
     }
 
+    public function deleteAllReverbReportRows()
+    {
+        $resourceSingleton = Mage::getResourceSingleton('reverb_reports/reverbreport');
+        return $resourceSingleton->deleteAllReverbReportRows();
+    }
+
     public function isListingCreationEnabled()
     {
         if (is_null($this->_listing_creation_is_enabled))

--- a/app/code/community/Reverb/ReverbSync/Model/Mysql4/Task/Listing.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Mysql4/Task/Listing.php
@@ -6,6 +6,8 @@
 
 class Reverb_ReverbSync_Model_Mysql4_Task_Listing extends Mage_Core_Model_Mysql4_Abstract
 {
+    const LISTING_TASK_CODE = 'listing_sync';
+
     const SERIALIZED_ARGUMENTS_OBJECT = 'O:8:"stdClass":1:{s:10:"product_id";i:##PRODUCT_ID##;}';
 
     public function _construct()
@@ -37,9 +39,14 @@ class Reverb_ReverbSync_Model_Mysql4_Task_Listing extends Mage_Core_Model_Mysql4
 
     public function deleteAllListingSyncTasks()
     {
-        $where_condition_array = array('code=?' => 'listing_sync');
+        $where_condition_array = array('code=?' => self::LISTING_TASK_CODE);
         $rows_deleted = $this->_getWriteAdapter()->delete($this->getMainTable(), $where_condition_array);
         return $rows_deleted;
+    }
+
+    public function deleteSuccessfulTasks()
+    {
+        return Mage::getResourceSingleton('reverb_process_queue/task')->deleteSuccessfulTasks(self::LISTING_TASK_CODE);
     }
 
     protected function _getInsertColumnsArray()
@@ -50,7 +57,7 @@ class Reverb_ReverbSync_Model_Mysql4_Task_Listing extends Mage_Core_Model_Mysql4
     protected function _getInsertDataArrayTemplate()
     {
         return array(
-            'code' => 'listing_sync',
+            'code' => self::LISTING_TASK_CODE,
             'status' => Reverb_ProcessQueue_Model_Task::STATUS_PENDING,
             'object' => 'reverbSync/sync_product',
             'method' => 'executeQueuedIndividualProductDataSync'

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/BaseController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/BaseController.php
@@ -75,6 +75,9 @@ abstract class Reverb_ReverbSync_Adminhtml_BaseController extends Mage_Adminhtml
         return $this;
     }
 
+    /**
+     * @return Reverb_ReverbSync_Helper_Admin
+     */
     protected function _getAdminHelper()
     {
         if (is_null($this->_adminHelper))

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Listings/SyncController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Listings/SyncController.php
@@ -4,10 +4,14 @@ require_once('Reverb/ReverbSync/controllers/Adminhtml/BaseController.php');
 class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_SyncController extends Reverb_ReverbSync_Adminhtml_BaseController
 {
     const BULK_SYNC_EXCEPTION = 'Error executing the Reverb Bulk Product Sync via the admin panel: %s';
+    const EXCEPTION_CLEARING_ALL_LISTING_TASKS = 'An error occurred while clearing all listing tasks from the system: %s';
+    const ERROR_CLEARING_SUCCESSFUL_SYNC = 'An error occurred while clearing successful listing syncs: %s';
     const SUCCESS_BULK_SYNC_COMPLETED = 'Reverb Bulk product sync process completed.';
     const SUCCESS_BULK_SYNC_QUEUED_UP = '%s products have been queued for sync. Please wait a few minutes and refresh this page...';
     const EXCEPTION_STOP_BULK_SYNC = 'Error attempting to stop all reverb listing sync tasks: %s';
     const SUCCESS_STOPPED_LISTING_SYNCS = 'Stopped all pending Reverb Listing Sync tasks';
+    const SUCCESS_CLEAR_LISTING_SYNCS = 'All listing sync tasks have been deleted';
+    const SUCCESS_CLEAR_SUCCESSFUL_LISTING_SYNCS = 'All successful listing sync tasks have been deleted';
 
     protected $_adminHelper = null;
 
@@ -58,6 +62,43 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Listings_SyncController extends Rev
         }
 
         $success_message = $this->__(self::SUCCESS_STOPPED_LISTING_SYNCS);
+        $this->_getAdminHelper()->addAdminSuccessMessage($success_message);
+        $this->_redirect('adminhtml/reports_reverbreport/index');
+    }
+
+    public function clearAllTasksAction()
+    {
+        try
+        {
+            $listing_sync_rows_deleted = Mage::helper('ReverbSync/sync_product')->deleteAllListingSyncTasks();
+            $reverb_report_rows_deleted = Mage::helper('ReverbSync/sync_product')->deleteAllReverbReportRows();
+        }
+        catch(Exception $e)
+        {
+            $error_message = $this->__(self::EXCEPTION_CLEARING_ALL_LISTING_TASKS, $e->getMessage());
+            $this->_getAdminHelper()->throwRedirectException($error_message, 'adminhtml/reports_reverbreport/index');
+        }
+
+        $success_message = $this->__(self::SUCCESS_CLEAR_LISTING_SYNCS);
+        $this->_getAdminHelper()->addAdminSuccessMessage($success_message);
+        $this->_redirect('adminhtml/reports_reverbreport/index');
+    }
+
+    public function clearSuccessfulTasksAction()
+    {
+        try
+        {
+            $listing_tasks_deleted = Mage::getResourceSingleton('reverbSync/task_listing')->deleteSuccessfulTasks();
+            $reverb_report_rows_deleted = Mage::getResourceSingleton('reverb_reports/reverbreport')
+                                            ->deleteSuccessfulSyncs();
+        }
+        catch(Exception $e)
+        {
+            $error_message = $this->__(self::ERROR_CLEARING_SUCCESSFUL_SYNC, $e->getMessage());
+            $this->_getAdminHelper()->throwRedirectException($error_message, 'adminhtml/reports_reverbreport/index');
+        }
+
+        $success_message = $this->__(self::SUCCESS_CLEAR_SUCCESSFUL_LISTING_SYNCS);
         $this->_getAdminHelper()->addAdminSuccessMessage($success_message);
         $this->_redirect('adminhtml/reports_reverbreport/index');
     }


### PR DESCRIPTION
Fix #171 

Due to the fact that the Listings Sync page has not been converted to the new backend architecture yet, there is currently no JS confirmation box appearing when users click on a Clear Tasks button on that page. On the other pages, a JS confirmation box will appear asking users if they are sure they want to clear the tasks.  Due to the sensitive nature of this update, I went through all of the buttons and checked the sql queries produced by them last night and again just now and they all look good.