### PR TITLE
Recommitting fix to reinitialize the Reverb Category table

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Model/Mysql4/Category/Reverb.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Mysql4/Category/Reverb.php
@@ -7,7 +7,7 @@
 class Reverb_ReverbSync_Model_Mysql4_Category_Reverb extends Mage_Core_Model_Mysql4_Abstract
 {
     protected $_database_insert_columns_array
-                = array('name', 'description', 'reverb_product_type_slug', 'reverb_category_slug');
+                = array('name', 'description', 'reverb_category_slug', 'reverb_product_type_slug');
 
     public function _construct()
     {

--- a/app/code/community/Reverb/ReverbSync/etc/config.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
   <modules>
     <Reverb_ReverbSync>
-      <version>0.1.10</version>
+      <version>0.1.12</version>
     </Reverb_ReverbSync>
   </modules>
   <global>

--- a/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.10-0.1.11.php
+++ b/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.10-0.1.11.php
@@ -1,0 +1,8 @@
+<?php
+
+$installer = $this;
+$installer->startSetup();
+
+Mage::getResourceSingleton('reverbSync/category_reverb')->initializeReverbCategoriesTable();
+
+$installer->endSetup();

--- a/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.11-0.1.12.php
+++ b/app/code/community/Reverb/ReverbSync/sql/reverbsync_setup/mysql4-upgrade-0.1.11-0.1.12.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * This migration script was intentionally committed twice as version 0.1.11 and 0.1.12 due to potential
+ *  inconsistencies in databases caused by the reversion of git commits on the master branch
+ */
+
+$installer = $this;
+$installer->startSetup();
+
+Mage::getResourceSingleton('reverbSync/category_reverb')->initializeReverbCategoriesTable();
+
+$installer->endSetup();


### PR DESCRIPTION
Fix #176 

I committed the migration twice just to be overly-cautious. It will not result in the values being populated twice