### PR TITLE
Fix 179 Allowing Make/Model/Price listing fields to be sent to Reverb…

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Model/Source/Product/Attribute.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Source/Product/Attribute.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Author: Sean Dunagan (https://github.com/dunagan5887)
+ * Created: 2/1/16
+ */
+
+class Reverb_ReverbSync_Model_Source_Product_Attribute
+{
+    public function toOptionArray()
+    {
+        $product_attributes_array = Mage::getResourceModel('catalog/product_attribute_collection')->getItems();
+        $options_array = array();
+        $options_array[''] = '';
+        foreach($product_attributes_array as $productAttribute)
+        {
+            $attribute_code = $productAttribute->getAttributeCode();
+            $attribute_label = $productAttribute->getFrontendLabel();
+            $attribute_label = (!empty($attribute_label)) ? $attribute_label : $attribute_code;
+            $options_array[$attribute_code] = $attribute_label;
+        }
+
+        asort($options_array);
+
+        return $options_array;
+    }
+}

--- a/app/code/community/Reverb/ReverbSync/etc/system.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/system.xml
@@ -186,6 +186,46 @@
           </fields>
         </listings_update_switches>
 
+          <listings_field_attributes>
+              <label>Listings Field Attributes</label>
+              <frontend_type>text</frontend_type>
+              <sort_order>175</sort_order>
+              <show_in_default>1</show_in_default>
+              <show_in_website>0</show_in_website>
+              <show_in_store>0</show_in_store>
+              <expanded>1</expanded>
+              <comment>The fields mapped here will be synced to Reverb using the values of the attributes on the products</comment>
+              <fields>
+                  <make translate="label">
+                      <label>Make</label>
+                      <frontend_type>select</frontend_type>
+                      <sort_order>10</sort_order>
+                      <show_in_default>1</show_in_default>
+                      <show_in_website>0</show_in_website>
+                      <show_in_store>0</show_in_store>
+                      <source_model>reverbSync/source_product_attribute</source_model>
+                  </make>
+                  <model translate="label">
+                      <label>Model</label>
+                      <frontend_type>select</frontend_type>
+                      <sort_order>20</sort_order>
+                      <show_in_default>1</show_in_default>
+                      <show_in_website>0</show_in_website>
+                      <show_in_store>0</show_in_store>
+                      <source_model>reverbSync/source_product_attribute</source_model>
+                  </model>
+                  <price translate="label">
+                      <label>Price</label>
+                      <frontend_type>select</frontend_type>
+                      <sort_order>30</sort_order>
+                      <show_in_default>1</show_in_default>
+                      <show_in_website>0</show_in_website>
+                      <show_in_store>0</show_in_store>
+                      <source_model>reverbSync/source_product_attribute</source_model>
+                  </price>
+              </fields>
+          </listings_field_attributes>
+
         <orders_sync translate="label">
           <label>Order Sync</label>
           <frontend_type>text</frontend_type>


### PR DESCRIPTION
Fix #179 Allowing Make/Model/Price listing fields to be sent to Reverb as Magento Product attribute values

I tested this on both CE 1.7 and 1.9