### PR TITLE
Reach back 3 days when syncing orders

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Retrieval/Creation.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Retrieval/Creation.php
@@ -7,7 +7,9 @@
 class Reverb_ReverbSync_Helper_Orders_Retrieval_Creation
     extends Reverb_ReverbSync_Helper_Orders_Retrieval
 {
-    const MINUTES_IN_PAST_FOR_CREATION_QUERY = 1440;
+    // We will fetch 3 days worth of orders at a time. This is to account for cron problems where
+    // the user might need to manually sync the orders
+    const MINUTES_IN_PAST_FOR_CREATION_QUERY = 4320; 
     const EXCEPTION_CHECK_IF_ORDER_ALREADY_SYNCED = 'Error checking to see if order with reverb id %s had already been created in Magento: %s';
 
     public function queueOrderActionByReverbOrderDataObject(stdClass $orderDataObject)

--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Retrieval/Update.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Retrieval/Update.php
@@ -7,8 +7,10 @@
 class Reverb_ReverbSync_Helper_Orders_Retrieval_Update extends Reverb_ReverbSync_Helper_Orders_Retrieval
 {
     const ORDERS_UPDATE_RETRIEVAL_URL_TEMPLATE = '/api/my/orders/selling/all?updated_start_date=%s';
-    // Choosing 11 minutes to account for the fact that this cron process may not run exactly on the minute
-    const MINUTES_IN_PAST_FOR_UPDATE_QUERY = 11;
+
+    // We will fetch 3 days worth of orders at a time. This is to account for cron problems where
+    // the user might need to manually sync the orders
+    const MINUTES_IN_PAST_FOR_UPDATE_QUERY = 4320;
 
     protected $_orderUpdateTaskResourceSingleton = null;
 


### PR DESCRIPTION
If the cron ends up not working for some time, it's easy to miss order updates. This changes reaches back 3 days for each order sync so that even if the cron hadn't fired, we can manually resync.