### PR TITLE
Add shipping_profile_name, finish, and year attributes for syncing

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Model/Mapper/Product.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Mapper/Product.php
@@ -28,7 +28,7 @@ class Reverb_ReverbSync_Model_Mapper_Product
     protected $_reverbConditionSourceModel = null;
     protected $_reverb_field_product_attributes = array();
 
-    protected $_reverb_fields_mapped_to_magento_attributes = array('make', 'model');
+    protected $_reverb_fields_mapped_to_magento_attributes = array('make', 'model', 'shipping_profile_name', 'finish', 'year');
 
     //LEGACY CODE: function to Map the Magento and Reverb attributes
     public function getUpdateListingWrapper(Mage_Catalog_Model_Product $product)

--- a/app/code/community/Reverb/ReverbSync/etc/config.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/config.xml
@@ -232,7 +232,7 @@
     <jobs>
       <reverb_process_queued_listing_sync_tasks>
         <schedule>
-          <cron_expr>*/2 * * * *</cron_expr>
+          <cron_expr>* * * * *</cron_expr>
         </schedule>
         <run>
           <model>reverbSync/cron_listings_sync::attemptCronExecution</model>
@@ -241,7 +241,7 @@
 
       <reverb_process_queued_listing_image_sync_tasks>
         <schedule>
-          <cron_expr>*/2 * * * *</cron_expr>
+          <cron_expr>* * * * *</cron_expr>
         </schedule>
         <run>
           <model>reverbSync/cron_listings_images_sync::attemptCronExecution</model>

--- a/app/code/community/Reverb/ReverbSync/etc/system.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/system.xml
@@ -252,6 +252,33 @@
                     <show_in_store>0</show_in_store>
                     <source_model>reverbSync/source_product_attribute</source_model>
                 </description>
+                <shipping_profile_name translate="label">
+                    <label>Shipping Profile (Name)</label>
+                    <frontend_type>select</frontend_type>
+                    <sort_order>50</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>0</show_in_website>
+                    <show_in_store>0</show_in_store>
+                    <source_model>reverbSync/source_product_attribute</source_model>
+                </shipping_profile_name>
+                <finish translate="label">
+                    <label>Finish (e.g. Pelham Blue) - For Guitars</label>
+                    <frontend_type>select</frontend_type>
+                    <sort_order>50</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>0</show_in_website>
+                    <show_in_store>0</show_in_store>
+                    <source_model>reverbSync/source_product_attribute</source_model>
+                </finish>
+                <year translate="label">
+                    <label>Year of manufacture - e.g. 1975 or range like 1960-1963</label>
+                    <frontend_type>select</frontend_type>
+                    <sort_order>50</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>0</show_in_website>
+                    <show_in_store>0</show_in_store>
+                    <source_model>reverbSync/source_product_attribute</source_model>
+                </year>
             </fields>
         </listings_field_attributes>
 


### PR DESCRIPTION
Adds shipping_profile_name, finish, and year to the synced attribute list. Customers will have to provide their own attributes for these. They will not be auto created.