### PR TITLE
Mass description update should trigger listing sync for all updated p…

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Helper/Sync/Listings/Update.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Sync/Listings/Update.php
@@ -55,6 +55,11 @@ class Reverb_ReverbSync_Helper_Sync_Listings_Update
             $magento_attributes[] = 'name';
         }
 
+        if ($this->isDescriptionUpdateEnabled())
+        {
+            $magento_attributes[] = 'description';
+        }
+
         $reverbProductMapper = Mage::getSingleton('reverbSync/mapper_product');
         /* @var $reverbProductMapper Reverb_ReverbSync_Model_Mapper_Product */
 


### PR DESCRIPTION
Fix #219 If the description field is set to be synced to Reverb, a mass product attribute update that updates the description field will trigger a listing sync for all updated products