### PR TITLE
Urlencode sku of product listing.

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Model/Mapper/Product.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Mapper/Product.php
@@ -35,6 +35,7 @@ class Reverb_ReverbSync_Model_Mapper_Product
     {
         $reverbListingWrapper = Mage::getModel('reverbSync/wrapper_listing');
         $sku = $product->getSku();
+        $sku = urlencode($sku);
         // $condition = $this->_getCondition();
 
         $fieldsArray = array('sku'=> $sku);
@@ -83,6 +84,7 @@ class Reverb_ReverbSync_Model_Mapper_Product
         $name = $product->getName();
         $description = $this->getProductDescription($product);
         $sku = $product->getSku();
+        $sku = urlencode($sku);
         $hasInventory = $this->_getHasInventory();
 
         $fieldsArray = array(


### PR DESCRIPTION
If you have a product with an SKU with a special character it won't sync correctly.

Here's an example. We had a product with a TAB symbol somehow ending up being part of SKU.
Say SKU in magento is "product-abcd".
Here's what happens to it.

Initial sync goes fine. The products sku is sent to reverb as "product-abcd\t"
Inventory updates -> Queued for re-sync.
On re-sync module checks if the product exists in the reverb via api using url containing the sku that is url encoded. So it checks for "product-abcd%9".
Obviously product with such sku doesn't exist, so module attempts to create a new listing for product with sku "product-abcd\t"
We get an error "SKU already exists in your shop. SKUs must be unique.already exists in your shop. SKUs must be unique." (fix the error message by the way).