### PR TITLE
#245 Order Creation page buttons redirect back to Order Creation page

### DIFF
--- a/app/code/community/Reverb/ProcessQueue/Block/Adminhtml/Task/Index.php
+++ b/app/code/community/Reverb/ProcessQueue/Block/Adminhtml/Task/Index.php
@@ -4,6 +4,12 @@
  * Created: 9/14/15
  */
 
+/**
+ * Author: Sean Dunagan (https://github.com/dunagan5887)
+ * Class Reverb_ProcessQueue_Block_Adminhtml_Task_Index
+ *
+ * @method Reverb_Base_Controller_Adminhtml_Abstract getAction()
+ */
 class Reverb_ProcessQueue_Block_Adminhtml_Task_Index
     extends Reverb_Base_Block_Adminhtml_Widget_Grid_Container
 {

--- a/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Orders/Index.php
+++ b/app/code/community/Reverb/ReverbSync/Block/Adminhtml/Orders/Index.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Author: Sean Dunagan (https://github.com/dunagan5887)
+ *
+ * Class Reverb_ReverbSync_Block_Adminhtml_Orders_Index
+ *
+ * @method Reverb_Base_Controller_Adminhtml_Abstract getAction()
+ */
 class Reverb_ReverbSync_Block_Adminhtml_Orders_Index extends Mage_Adminhtml_Block_Widget_Container
 {
     const LAST_EXECUTED_AT_TEMPLATE = '<h3>The last Sync Task was executed at %s</h3>';
@@ -28,13 +35,21 @@ class Reverb_ReverbSync_Block_Adminhtml_Orders_Index extends Mage_Adminhtml_Bloc
 
         $this->setTemplate('ReverbSync/sales/order/index/container.phtml');
 
+        $order_sync_actions_controller = $this->getAction()->getIndexActionsController();
+        $bulk_sync_action_url = Mage::getModel('adminhtml/url')
+                                    ->getUrl('adminhtml/ReverbSync_orders_sync/bulkSync',
+                                             array('redirect_controller' => $order_sync_actions_controller));
+
         $bulk_orders_sync_process_button = array(
-            'action_url' => Mage::getModel('adminhtml/url')->getUrl('adminhtml/ReverbSync_orders_sync/bulkSync'),
+            'action_url' => $bulk_sync_action_url,
             'label' => $this->_retrieveAndProcessTasksButtonLabel()
         );
 
+        $process_downloaded_tasks_action_url = Mage::getModel('adminhtml/url')
+                                                ->getUrl('adminhtml/ReverbSync_orders_sync/syncDownloaded',
+                                                    array('redirect_controller' => $order_sync_actions_controller));
         $process_downloaded_tasks_button = array(
-            'action_url' => Mage::getModel('adminhtml/url')->getUrl('adminhtml/ReverbSync_orders_sync/syncDownloaded'),
+            'action_url' => $process_downloaded_tasks_action_url,
             'label' => $this->_processDownloadedTasksButtonLabel()
         );
 
@@ -166,6 +181,9 @@ class Reverb_ReverbSync_Block_Adminhtml_Orders_Index extends Mage_Adminhtml_Bloc
         return 'order_update';
     }
 
+    /**
+     * @return Reverb_ProcessQueue_Helper_Task_Processor
+     */
     protected function _getTaskProcessorHelper()
     {
         return Mage::helper('reverb_process_queue/task_processor');

--- a/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Orders/SyncController.php
+++ b/app/code/community/Reverb/ReverbSync/controllers/Adminhtml/ReverbSync/Orders/SyncController.php
@@ -63,7 +63,8 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_SyncController
         }
 
         Mage::getSingleton('adminhtml/session')->addNotice($this->__(self::NOTICE_QUEUED_ORDERS_FOR_SYNC));
-        $this->_redirect('*/*/index');
+
+        $this->_redirectBasedOnRequestParameter();
     }
 
     public function syncDownloadedAction()
@@ -83,7 +84,21 @@ class Reverb_ReverbSync_Adminhtml_ReverbSync_Orders_SyncController
         }
 
         Mage::getSingleton('adminhtml/session')->addNotice($this->__(self::NOTICE_PROCESSING_DOWNLOADED_TASKS));
-        $this->_redirect('*/*/index');
+
+        $this->_redirectBasedOnRequestParameter();
+    }
+
+    /**
+     * Returns the appropriate redirect path for the request based on the page which the request came from
+     *
+     * @return string
+     */
+    protected function _redirectBasedOnRequestParameter()
+    {
+        $redirect_controller_param = $this->getRequest()->getParam('redirect_controller');
+        $redirect_path_controller = (!empty($redirect_controller_param)) ? $redirect_controller_param : '*';
+        $redirect_path = sprintf('*/%s/index', $redirect_path_controller);
+        $this->_redirect($redirect_path);
     }
 
     public function canAdminUpdateStatus()


### PR DESCRIPTION
Fix #245 I tested this on 1.9, 1.7 and 1.12, looks good to go