### PR TITLE
#264 Delete old sync tasks after a period of time

### DIFF
--- a/app/code/community/Reverb/ProcessQueue/Helper/Task.php
+++ b/app/code/community/Reverb/ProcessQueue/Helper/Task.php
@@ -6,7 +6,14 @@
 
 class Reverb_ProcessQueue_Helper_Task extends Mage_Core_Helper_Data
 {
-    const STALE_TIME_LAPSE = '-2 weeks';
+    /**
+     * It's not optimal that the configuration setting for this Reverb_ProcessQueue module class is in the ReverbSync
+     *  module's configuration setting, but creating a Reverb_ProcessQueue module-specific system.xml tab and
+     *  section seemed like sub-optimal UX. As such, this setting is in the already-existing ReverbSync module's
+     *  system.xml structure.
+     */
+    const STALE_TASK_TIME_LAPSE_CONFIG_PATH = 'ReverbSync/stale_task_deletion/stale_period_in_days';
+    const STALE_TASK_TIME_LAPSE_SPRINTF_TEMPLATE = '-%s days';
 
     /**
      * The calling block is expected to catch exceptions
@@ -17,14 +24,34 @@ class Reverb_ProcessQueue_Helper_Task extends Mage_Core_Helper_Data
     public function deleteStaleSuccessfulTasks($task_code = null)
     {
         $current_gmt_timestamp = Mage::getSingleton('core/date')->gmtTimestamp();
-        $stale_timestamp = strtotime(self::STALE_TIME_LAPSE, $current_gmt_timestamp);
+        $stale_task_time_lapse_strtotime_param = $this->_getStaleTaskTimeLapseInDaysStrToTimeParam();
+        $stale_timestamp = strtotime($stale_task_time_lapse_strtotime_param, $current_gmt_timestamp);
         $stale_date = date('Y-m-d H:i:s', $stale_timestamp);
-
-        $rows_deleted = Mage::getResourceSingleton('reverb_process_queue/task')
-                            ->deleteSuccessfulTasks($task_code, $stale_date);
-        $unique_rows_deleted = Mage::getResourceSingleton('reverb_process_queue/task_unique')
-                                ->deleteSuccessfulTasks($task_code, $stale_date);
+        // Flush the task table
+        $taskResourceSingleton = Mage::getResourceSingleton('reverb_process_queue/task');
+        /* @var Reverb_ProcessQueue_Model_Mysql4_Task $taskResourceSingleton */
+        $rows_deleted = $taskResourceSingleton->deleteSuccessfulTasks($task_code, $stale_date);
+        // Flush the unique task table
+        $uniqueTaskResourceSingleton = Mage::getResourceSingleton('reverb_process_queue/task_unique');
+        /* @var Reverb_ProcessQueue_Model_Mysql4_Task_Unique $uniqueTaskResourceSingleton */
+        $unique_rows_deleted = $uniqueTaskResourceSingleton->deleteSuccessfulTasks($task_code, $stale_date);
 
         return ($rows_deleted + $unique_rows_deleted);
+    }
+
+    /**
+     * Returns the first parameter for strtotime signifying the time in days that tasks should be completed for
+     *  in order to be considered stale
+     *
+     * @return string
+     */
+    protected function _getStaleTaskTimeLapseInDaysStrToTimeParam()
+    {
+        $stale_task_time_lapse_in_days = Mage::getStoreConfig(self::STALE_TASK_TIME_LAPSE_CONFIG_PATH);
+        $stale_task_time_lapse_in_days = intval($stale_task_time_lapse_in_days);
+        $stale_task_time_lapse_strtotime_param
+            = sprintf(self::STALE_TASK_TIME_LAPSE_SPRINTF_TEMPLATE, $stale_task_time_lapse_in_days);
+
+        return $stale_task_time_lapse_strtotime_param;
     }
 }

--- a/app/code/community/Reverb/ProcessQueue/Model/Cron/Delete/Stale/Successful.php
+++ b/app/code/community/Reverb/ProcessQueue/Model/Cron/Delete/Stale/Successful.php
@@ -8,12 +8,34 @@ class Reverb_ProcessQueue_Model_Cron_Delete_Stale_Successful
 {
     const CRON_UNCAUGHT_EXCEPTION = 'Error deleting stale success tasks from the Reverb Process Queue: %s';
 
+    /**
+     * It's not optimal that the configuration setting for this Reverb_ProcessQueue module class is in the ReverbSync
+     *  module's configuration setting, but creating a Reverb_ProcessQueue module-specific system.xml tab and
+     *  section seemed like sub-optimal UX. As such, this setting is in the already-existing ReverbSync module's
+     *  system.xml structure.
+     */
+    const STALE_TASK_DELETION_ENABLED_CONFIG_PATH = 'ReverbSync/stale_task_deletion/enabled';
+
+    /**
+     * @var null|bool
+     */
+    protected $_is_stale_task_deletion_enabled = null;
+
+    /**
+     * A nightly cronjob to delete tasks from the system which are "stale", meaning have been completed for a period of
+     *  time defined in the admin panel
+     */
     public function deleteStaleSuccessfulQueueTasks()
     {
         try
         {
-            Mage::helper('reverb_process_queue/task')->deleteStaleSuccessfulTasks();
-
+            // See if the nightly cronjob to delete stale successful tasks has been enabled
+            if ($this->_isStaleTaskDeletionEnabled())
+            {
+                $taskHelper = Mage::helper('reverb_process_queue/task');
+                /* @var Reverb_ProcessQueue_Helper_Task $taskHelper */
+                $taskHelper->deleteStaleSuccessfulTasks();
+            }
         }
         catch(Exception $e)
         {
@@ -22,5 +44,19 @@ class Reverb_ProcessQueue_Model_Cron_Delete_Stale_Successful
             $exceptionToLog = new Exception($error_message);
             Mage::logException($exceptionToLog);
         }
+    }
+
+    /**
+     * @return bool
+     */
+    protected function _isStaleTaskDeletionEnabled()
+    {
+        if (is_null($this->_is_stale_task_deletion_enabled))
+        {
+            $stale_task_deletion_is_enabled = Mage::getStoreConfig(self::STALE_TASK_DELETION_ENABLED_CONFIG_PATH);
+            $this->_is_stale_task_deletion_enabled = boolval($stale_task_deletion_is_enabled);
+        }
+
+        return $this->_is_stale_task_deletion_enabled;
     }
 }

--- a/app/code/community/Reverb/ProcessQueue/etc/config.xml
+++ b/app/code/community/Reverb/ProcessQueue/etc/config.xml
@@ -65,7 +65,7 @@
         <jobs>
             <reverb_process_queue_delete_stale_successful>
                 <schedule>
-                    <cron_expr>36 4 * * *</cron_expr>
+                    <cron_expr>19 3 * * *</cron_expr>
                 </schedule>
                 <run>
                     <model>reverb_process_queue/cron_delete_stale_successful::deleteStaleSuccessfulQueueTasks</model>

--- a/app/code/community/Reverb/ReverbSync/etc/config.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/config.xml
@@ -334,6 +334,10 @@
         <!-- Default orders to be synced to the Admin store -->
         <store_to_sync_order_to>0</store_to_sync_order_to>
       </orders_sync>
+      <stale_task_deletion>
+        <enabled>1</enabled>
+        <stale_period_in_days>7</stale_period_in_days>
+      </stale_task_deletion>
     </ReverbSync>
   </default>
 </config>

--- a/app/code/community/Reverb/ReverbSync/etc/system.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/system.xml
@@ -349,6 +349,40 @@
             </store_to_sync_order_to>
           </fields>
         </orders_sync>
+
+          <stale_task_deletion translate="label">
+              <label>Stale Task Deletion</label>
+              <frontend_type>text</frontend_type>
+              <sort_order>250</sort_order>
+              <show_in_default>1</show_in_default>
+              <show_in_website>1</show_in_website>
+              <show_in_store>1</show_in_store>
+              <expanded>1</expanded>
+
+              <fields>
+                  <enabled translate="label">
+                      <label>Enable Deletion of Stale Tasks</label>
+                      <comment>To delete tasks which have been completed in the system for more than the amount of days configured below, set this to "Yes"</comment>
+                      <frontend_type>select</frontend_type>
+                      <sort_order>10</sort_order>
+                      <show_in_default>1</show_in_default>
+                      <show_in_website>1</show_in_website>
+                      <show_in_store>1</show_in_store>
+                      <source_model>adminhtml/system_config_source_yesno</source_model>
+                      <validate>required-entry</validate>
+                  </enabled>
+                  <stale_period_in_days>
+                      <label>Period to define as stale</label>
+                      <comment>If the above setting is set to "Yes", any completed task in the system which is older than this value will be deleted from the system during a nightly cronjob.</comment>
+                      <frontend_type>text</frontend_type>
+                      <sort_order>20</sort_order>
+                      <show_in_default>1</show_in_default>
+                      <show_in_website>1</show_in_website>
+                      <show_in_store>1</show_in_store>
+                      <validate>validate-greater-than-zero required-entry</validate>
+                  </stale_period_in_days>
+                </fields>
+            </stale_task_deletion>
       </groups>
     </ReverbSync>
   </sections>


### PR DESCRIPTION
Fix #264 Implementing configuration settings allowing to customize the length of time tasks will be stale before being deleted from the system