### PR TITLE
#266 Don't create orders if using Awaiting Shipment sync

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Model/Source/Order/Status.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Source/Order/Status.php
@@ -9,32 +9,31 @@
  */
 class Reverb_ReverbSync_Model_Source_Order_Status
 {
-    const NON_PAID_ORDER_STATUS_CONFIG_PATH = 'ReverbSync/orders_sync/non_paid_order_statuses';
+    const PAID_ORDER_STATUSES_CONFIG_PATH = 'ReverbSync/orders_sync/paid_order_statuses';
 
     /**
      * @var null|array
      */
-    protected $_non_paid_order_statuses_array = null;
+    protected $_paid_order_statuses_array = null;
 
     /**
-     * Returns an array containing the order statuses which should be considered as not having been paid
+     * Returns an array containing the Reverb Order statuses which have been configured as being "paid" in the system
      *
      * @return array
      */
-    public function getNonPaidOrderStatuses()
+    public function getPaidOrderStatusesArray()
     {
-        if (is_null($this->_non_paid_order_statuses_array))
+        if (is_null($this->_paid_order_statuses_array))
         {
-            $non_paid_order_statuses = Mage::getStoreConfig(self::NON_PAID_ORDER_STATUS_CONFIG_PATH);
-            if (!is_array($non_paid_order_statuses))
+            $paid_order_statuses_array = Mage::getStoreConfig(self::PAID_ORDER_STATUSES_CONFIG_PATH);
+            if (!is_array($paid_order_statuses_array))
             {
-                // If no statuses have been configured as non-paid, return an empty array
+                // If no statuses have been configured as paid, return an empty array
                 return array();
             }
-            $non_paid_order_statuses = array_keys($non_paid_order_statuses);
-            $this->_non_paid_order_statuses_array = $non_paid_order_statuses;
+            $this->_paid_order_statuses_array = array_keys($paid_order_statuses_array);
         }
 
-        return $this->_non_paid_order_statuses_array;
+        return $this->_paid_order_statuses_array;
     }
 }

--- a/app/code/community/Reverb/ReverbSync/Model/Source/Order/Status.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Source/Order/Status.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Author: Sean Dunagan (github: dunagan5887)
+ * Date: 11/7/16
+ */
+
+/**
+ * Class Reverb_ReverbSync_Model_Source_Order_Status
+ */
+class Reverb_ReverbSync_Model_Source_Order_Status
+{
+    const NON_PAID_ORDER_STATUS_CONFIG_PATH = 'ReverbSync/orders_sync/non_paid_order_statuses';
+
+    /**
+     * @var null|array
+     */
+    protected $_non_paid_order_statuses_array = null;
+
+    /**
+     * Returns an array containing the order statuses which should be considered as not having been paid
+     *
+     * @return array
+     */
+    public function getNonPaidOrderStatuses()
+    {
+        if (is_null($this->_non_paid_order_statuses_array))
+        {
+            $non_paid_order_statuses = Mage::getStoreConfig(self::NON_PAID_ORDER_STATUS_CONFIG_PATH);
+            if (!is_array($non_paid_order_statuses))
+            {
+                // If no statuses have been configured as non-paid, return an empty array
+                return array();
+            }
+            $non_paid_order_statuses = array_keys($non_paid_order_statuses);
+            $this->_non_paid_order_statuses_array = $non_paid_order_statuses;
+        }
+
+        return $this->_non_paid_order_statuses_array;
+    }
+}

--- a/app/code/community/Reverb/ReverbSync/Model/Source/Orderurl.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Source/Orderurl.php
@@ -17,6 +17,40 @@ class Reverb_ReverbSync_Model_Source_Orderurl
     const ORDERS_AWAITING_SHIPMENT_URL = '/api/my/orders/selling/awaiting_shipment?updated_start_date=%s';
     const ORDERS_AWAITING_SHIPMENT_LABEL = 'Paid Orders Awaiting Shipment';
 
+    const SOURCE_ORDER_URL_CONFIG = 'ReverbSync/orders_sync/order_sync_reverb_source_url';
+
+    /**
+     * @var null|bool
+     */
+    protected $_only_sync_paid_orders = null;
+
+    /**
+     * Returns whether the client has configured the order creation sync process to only sync orders which are awaiting
+     *  shipment
+     *
+     * @return bool
+     */
+    public function shouldOnlySyncPaidOrders()
+    {
+        if (is_null($this->_only_sync_paid_orders))
+        {
+            $order_sync_source_url_configuration_setting = Mage::getStoreConfig(self::SOURCE_ORDER_URL_CONFIG);
+            // trim the field just to be safe
+            $order_sync_source_url_configuration_setting = trim($order_sync_source_url_configuration_setting);
+            // Compare the field to the constant above
+            if (!strcmp($order_sync_source_url_configuration_setting, self::ALL_ORDERS_URL))
+            {
+                $this->_only_sync_paid_orders = false;
+            }
+            else
+            {
+                $this->_only_sync_paid_orders = true;
+            }
+        }
+
+        return $this->_only_sync_paid_orders;
+    }
+
     /**
      * Options getter
      *

--- a/app/code/community/Reverb/ReverbSync/Model/Sync/Order/Update.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Sync/Order/Update.php
@@ -96,8 +96,8 @@ class Reverb_ReverbSync_Model_Sync_Order_Update extends Reverb_ProcessQueue_Mode
      *
      * IF the user has "Paid Orders Awaiting Shipment" setting
      *      on update, poll the endpoint (still using the "all" endpoint as we do want all updates)
-     *      if the status on an order is unpaid/pending_review/blocked, do NOT create the order
-     *      otherwise create the order
+     *      if the status on an order is paid, create the order
+     *      otherwise do NOT create the order
      *
      * IF the user has the All Orders setting,
      *      on update, create the order regardless of status
@@ -115,8 +115,8 @@ class Reverb_ReverbSync_Model_Sync_Order_Update extends Reverb_ProcessQueue_Mode
         }
         // Check the update status for the order
         $reverb_order_status = $argumentsObject->status;
-        $non_paid_order_statuses_array = $this->_getOrderStatusSourceSingleton()->getNonPaidOrderStatuses();
-        $should_create_order = (!in_array($reverb_order_status, $non_paid_order_statuses_array));
+        $paid_order_statuses_array = $this->_getOrderStatusSourceSingleton()->getPaidOrderStatusesArray();
+        $should_create_order = in_array($reverb_order_status, $paid_order_statuses_array);
         return $should_create_order;
     }
 

--- a/app/code/community/Reverb/ReverbSync/Model/Sync/Order/Update.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Sync/Order/Update.php
@@ -11,8 +11,19 @@ class Reverb_ReverbSync_Model_Sync_Order_Update extends Reverb_ProcessQueue_Mode
     const EXCEPTION_EXECUTING_STATUS_UPDATE = 'Exception occurred while executing the status update for order with magento entity id %s to status %s: %s';
     const EXCEPTION_CREATING_ORDER = 'An exception occurred while creating order with Reverb Order Number %s: %s';
     const SUCCESS_ORDER_STATUS_UPDATED = 'The order\'s status has been updated to %s';
+    const NOTICE_ORDER_NOT_PAID = 'Reverb Order #%s has not yet been paid, and will not be created in the Magento system at this time as a result';
 
     protected $_orderCreationHelper = null;
+
+    /**
+     * @var null|Reverb_ReverbSync_Model_Source_Orderurl
+     */
+    protected $_orderCreationRetrievalUrlSource = null;
+
+    /**
+     * @var null|Reverb_ReverbSync_Model_Source_Order_Status
+     */
+    protected $_orderStatusSource = null;
 
     public function updateReverbOrderInMagento(stdClass $argumentsObject)
     {
@@ -30,34 +41,83 @@ class Reverb_ReverbSync_Model_Sync_Order_Update extends Reverb_ProcessQueue_Mode
 
         if (empty($magento_order_entity_id))
         {
-            // In this event, we will create the order
-            try
+            /**
+             * In this event, we will adhere to the following business logic
+             * IF the user has "Paid Orders Awaiting Shipment" setting
+             *      on update, poll the endpoint (still using the "all" endpoint as we do want all updates)
+             *      if the status on an order is unpaid/pending_review/blocked, do NOT create the order
+             *      otherwise create the order
+             *
+             * IF the user has the All Orders setting,
+             *      on update, create the order regardless of status
+             */
+            if ($this->_shouldCreateOrderDueToUpdateTransmission($argumentsObject))
             {
-                $magentoOrder = $this->_getOrderCreationHelper()->createMagentoOrder($argumentsObject);
-                // Get the magento order entity id from the newly created order
-                if ((!is_object($magentoOrder)) || (!$magentoOrder->getId()))
+                try
                 {
-                    // If the order is not a loaded object in the database, throw an exception
-                    $error_message = Mage::helper('ReverbSync')
-                                        ->__(self::ERROR_MAGENTO_ORDER_NOT_CREATED, $reverb_order_number);
-                    throw new Exception($error_message);
-                }
+                    $magentoOrder = $this->_getOrderCreationHelper()->createMagentoOrder($argumentsObject);
+                    // Get the magento order entity id from the newly created order
+                    if ((!is_object($magentoOrder)) || (!$magentoOrder->getId()))
+                    {
+                        // If the order is not a loaded object in the database, throw an exception
+                        $error_message = Mage::helper('ReverbSync')
+                                            ->__(self::ERROR_MAGENTO_ORDER_NOT_CREATED, $reverb_order_number);
+                        throw new Exception($error_message);
+                    }
 
-                $magento_order_entity_id = $magentoOrder->getId();
+                    $magento_order_entity_id = $magentoOrder->getId();
+                }
+                catch(Exception $e)
+                {
+                    // In this event, log the error and return an Abort status
+                    $error_message = Mage::helper('ReverbSync')->__(self::EXCEPTION_CREATING_ORDER, $reverb_order_number,
+                        $e->getMessage());
+                    Mage::getSingleton('reverbSync/log')->logOrderSyncError($error_message);
+                    return $this->_returnAbortCallbackResult($error_message);
+                }
             }
-            catch(Exception $e)
+            else
             {
-                // In this event, log the error and return an Abort status
-                $error_message = Mage::helper('ReverbSync')->__(self::EXCEPTION_CREATING_ORDER, $reverb_order_number,
-                                                                $e->getMessage());
-                Mage::getSingleton('reverbSync/log')->logOrderSyncError($error_message);
-                return $this->_returnAbortCallbackResult($error_message);
+                // In this case, do not create the order and return a Complete status for the task
+                // Once the order becomes paid, a new order update will be created in the Reverb system which will
+                //      trigger creation of the order
+                $notice_message = Mage::helper('ReverbSync')->__(self::NOTICE_ORDER_NOT_PAID, $reverb_order_number);
+                return $this->_returnSuccessCallbackResult($notice_message);
             }
         }
 
         $reverb_order_status = $argumentsObject->status;
 
         return $this->_executeStatusUpdate($magento_order_entity_id, $reverb_order_status, $argumentsObject);
+    }
+
+    /**
+     * Will return whether or not the order should be create in the Magento system as per the following logic:
+     *
+     * IF the user has "Paid Orders Awaiting Shipment" setting
+     *      on update, poll the endpoint (still using the "all" endpoint as we do want all updates)
+     *      if the status on an order is unpaid/pending_review/blocked, do NOT create the order
+     *      otherwise create the order
+     *
+     * IF the user has the All Orders setting,
+     *      on update, create the order regardless of status
+     *
+     * @param stdClass $argumentsObject
+     * @return bool
+     */
+    protected function _shouldCreateOrderDueToUpdateTransmission(stdClass $argumentsObject)
+    {
+        // Check if the user has set Order Creation to be scoped to "All Orders"
+        if (!$this->_getOrderCreationRetrievalUrlSource()->shouldOnlySyncPaidOrders())
+        {
+            // The order should be created regardless of its update status
+            return true;
+        }
+        // Check the update status for the order
+        $reverb_order_status = $argumentsObject->status;
+        $non_paid_order_statuses_array = $this->_getOrderStatusSourceSingleton()->getNonPaidOrderStatuses();
+        $should_create_order = (!in_array($reverb_order_status, $non_paid_order_statuses_array));
+        return $should_create_order;
     }
 
     /**
@@ -113,6 +173,32 @@ class Reverb_ReverbSync_Model_Sync_Order_Update extends Reverb_ProcessQueue_Mode
 
         $success_message = Mage::helper('ReverbSync')->__(self::SUCCESS_ORDER_STATUS_UPDATED, $reverb_order_status);
         return $this->_returnSuccessCallbackResult($success_message);
+    }
+
+    /**
+     * @return Reverb_ReverbSync_Model_Source_Order_Status
+     */
+    protected function _getOrderStatusSourceSingleton()
+    {
+        if (is_null($this->_orderStatusSource))
+        {
+            $this->_orderStatusSource = Mage::getSingleton('reverbSync/source_order_status');
+        }
+
+        return $this->_orderStatusSource;
+    }
+
+    /**
+     * @return Reverb_ReverbSync_Model_Source_Orderurl
+     */
+    protected function _getOrderCreationRetrievalUrlSource()
+    {
+        if (is_null($this->_orderCreationRetrievalUrlSource))
+        {
+            $this->_orderCreationRetrievalUrlSource = Mage::getSingleton('reverbSync/source_orderurl');
+        }
+
+        return $this->_orderCreationRetrievalUrlSource;
     }
 
     /**

--- a/app/code/community/Reverb/ReverbSync/etc/config.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/config.xml
@@ -334,11 +334,9 @@
         <!-- Default orders to be synced to the Admin store -->
         <store_to_sync_order_to>0</store_to_sync_order_to>
         <!-- The set of order statuses which should be regarded as constituting NOT being a paid order -->
-        <non_paid_order_statuses>
-          <unpaid/>
-          <pending_review/>
-          <blocked/>
-        </non_paid_order_statuses>
+        <paid_order_statuses>
+          <paid/>
+        </paid_order_statuses>
       </orders_sync>
     </ReverbSync>
   </default>

--- a/app/code/community/Reverb/ReverbSync/etc/config.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/config.xml
@@ -333,6 +333,12 @@
         <order_sync_reverb_source_url>/api/my/orders/selling/all?created_start_date=%s</order_sync_reverb_source_url>
         <!-- Default orders to be synced to the Admin store -->
         <store_to_sync_order_to>0</store_to_sync_order_to>
+        <!-- The set of order statuses which should be regarded as constituting NOT being a paid order -->
+        <non_paid_order_statuses>
+          <unpaid/>
+          <pending_review/>
+          <blocked/>
+        </non_paid_order_statuses>
       </orders_sync>
     </ReverbSync>
   </default>


### PR DESCRIPTION
#266 Fix to not create non-paid status Reverb orders in the Magento system if the user has configured order creation to only occur for Paid Orders Awaiting Shipment

I tested this on Magento 1.9 and 1.7 and it looks good to go