### PR TITLE
#268 Creating configuration option to disable Reverb module logging

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Helper/Data.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Data.php
@@ -24,10 +24,14 @@ class Reverb_ReverbSync_Helper_Data
     const LISTING_STATUS_SUCCESS = 1;
 
     /**
-     * $fieldsArray should eventually be a model
-     *
-     * @param $listingWrapper
-     * @return Reverb_ReverbSync_Model_Wrapper_Listing
+     * @var null|Reverb_ReverbSync_Model_Log
+     */
+    protected $_getLogSingleton = null;
+
+    /**
+     * @param $product
+     * @param bool $do_not_allow_creation
+     * @return false|Reverb_ReverbSync_Model_Wrapper_Listing
      */
     public function createOrUpdateReverbListing($product, $do_not_allow_creation = false)
     {
@@ -429,6 +433,19 @@ class Reverb_ReverbSync_Helper_Data
     {
         $message = sprintf(self::API_CALL_LOG_TEMPLATE, $api_request, $request, $status, $response);
         $file = 'reverb_sync_' . $api_request . '.log';
-        Mage::log($message, null, $file);
+        $this->_getLogSingleton()->logReverbMessage($message, $file);
+    }
+
+    /**
+     * @return Reverb_ReverbSync_Model_Log
+     */
+    protected function _getLogSingleton()
+    {
+        if (is_null($this->_getLogSingleton))
+        {
+            $this->_getLogSingleton = Mage::getSingleton('reverbSync/log');
+        }
+
+        return $this->_getLogSingleton;
     }
 }

--- a/app/code/community/Reverb/ReverbSync/Helper/Orders/Sync.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Orders/Sync.php
@@ -55,12 +55,19 @@ class Reverb_ReverbSync_Helper_Orders_Sync extends Mage_Core_Helper_Abstract
         return Mage::getStoreConfig(self::ORDER_SYNC_SUPER_MODE_ENABLED_CONFIG_PATH);
     }
 
+    /**
+     * @return string
+     */
     public function logOrderSyncDisabledMessage()
     {
         $error_message = $this->getOrderSyncIsDisabledMessage();
         Mage::getSingleton('reverbSync/log')->logOrderSyncError($error_message);
+        return $error_message;
     }
 
+    /**
+     * @return string
+     */
     public function getOrderSyncIsDisabledMessage()
     {
         if (is_null($this->_order_sync_is_disabled_message))

--- a/app/code/community/Reverb/ReverbSync/Model/Adapter/Curl.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Adapter/Curl.php
@@ -18,6 +18,11 @@ class Reverb_ReverbSync_Model_Adapter_Curl
 
     const REQUEST_LOG_FILE = 'reverb_curl_requests.log';
 
+    /**
+     * @var null|Reverb_ReverbSync_Model_Log
+     */
+    protected $_getLogSingleton = null;
+
     protected function _applyConfig()
     {
         $this->_addCurrentMagentoVersionUserAgent();
@@ -157,7 +162,7 @@ class Reverb_ReverbSync_Model_Adapter_Curl
         }
 
         $string_to_log = sprintf(self::REQUEST_LOG_TEMPLATE, $http_method_log, $http_header_string_to_log, $url_to_log, $body_to_log);
-        Mage::log($string_to_log, null, self::REQUEST_LOG_FILE);
+        $this->_logApiRequestMessage($string_to_log);
 
         $status = $this->getRequestHttpCode();
         $status_as_int = intval($status);
@@ -165,7 +170,7 @@ class Reverb_ReverbSync_Model_Adapter_Curl
         {
             $curl_error = $this->getCurlErrorMessage();
             $error_string_to_log = sprintf(self::POST_ERROR_LOG_TEMPLATE, $curl_error);
-            Mage::log($error_string_to_log, null, self::REQUEST_LOG_FILE);
+            $this->_logApiRequestMessage($error_string_to_log);
         }
     }
 
@@ -437,5 +442,26 @@ class Reverb_ReverbSync_Model_Adapter_Curl
         }
         curl_multi_close($multihandle);
         return $result;
+    }
+
+    /**
+     * @param string $api_message
+     */
+    protected function _logApiRequestMessage($api_message)
+    {
+        $this->_getLogSingleton()->logApiRequestMessage($api_message);
+    }
+
+    /**
+     * @return Reverb_ReverbSync_Model_Log
+     */
+    protected function _getLogSingleton()
+    {
+        if (is_null($this->_getLogSingleton))
+        {
+            $this->_getLogSingleton = Mage::getSingleton('reverbSync/log');
+        }
+
+        return $this->_getLogSingleton;
     }
 }

--- a/app/code/community/Reverb/ReverbSync/Model/Log.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Log.php
@@ -8,6 +8,13 @@ class Reverb_ReverbSync_Model_Log
 {
     const LOG_FILE_PREFIX = 'reverb_sync';
 
+    const REVERB_LOGGING_ENABLED_CONFIG_PATH = 'ReverbSync/extensionOption_group/enable_logging';
+
+    /**
+     * @var null|bool
+     */
+    protected $_logging_is_enabled = null;
+
     public function setSessionErrorIfAdminIsLoggedIn($error_message)
     {
         if (Mage::helper('reverb_base')->isAdminLoggedIn())
@@ -46,6 +53,22 @@ class Reverb_ReverbSync_Model_Log
         $this->logSyncError($error_message, 'listing_images');
     }
 
+    /**
+     * @param string $message
+     */
+    public function logApiRequestMessage($message)
+    {
+        $log_file = 'reverb_curl_requests.log';
+        $this->logReverbMessage($message, $log_file);
+    }
+
+    /**
+     * Log a Reverb sync error message if logging has been enabled for the Reverb module
+     * If not, do nothing
+     *
+     * @param $error_message
+     * @param null $sync_process
+     */
     public function logSyncError($error_message, $sync_process = null)
     {
         if (is_null($sync_process))
@@ -54,6 +77,31 @@ class Reverb_ReverbSync_Model_Log
         }
 
         $log_file = self::LOG_FILE_PREFIX . '_' . $sync_process . '.log';
-        Mage::log($error_message, null, $log_file);
+        $this->logReverbMessage($error_message, $log_file);
+    }
+
+    public function logReverbMessage($message, $file_to_log_to)
+    {
+        if (!$this->_isReverbLoggingEnabled())
+        {
+            // Logging is not enabled for the Reverb module, so do nothing
+            return;
+        }
+
+        Mage::log($message, null, $file_to_log_to);
+    }
+
+    /**
+     * @return bool
+     */
+    protected function _isReverbLoggingEnabled()
+    {
+        if (is_null($this->_logging_is_enabled))
+        {
+            $reverb_logging_is_enabled = Mage::getStoreConfig(self::REVERB_LOGGING_ENABLED_CONFIG_PATH);
+            $this->_logging_is_enabled = (bool)$reverb_logging_is_enabled;
+        }
+    
+        return $this->_logging_is_enabled;
     }
 }

--- a/app/code/community/Reverb/ReverbSync/Model/Sync/Order/Update.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Sync/Order/Update.php
@@ -19,7 +19,6 @@ class Reverb_ReverbSync_Model_Sync_Order_Update extends Reverb_ProcessQueue_Mode
         if (!Mage::helper('ReverbSync/orders_sync')->isOrderSyncEnabled())
         {
             $error_message = Mage::helper('ReverbSync/orders_sync')->logOrderSyncDisabledMessage();
-            Mage::getModel('reverbSync/log')->logOrderSyncError($error_message);
             return $this->_returnAbortCallbackResult($error_message);
         }
 

--- a/app/code/community/Reverb/ReverbSync/etc/config.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/config.xml
@@ -307,6 +307,10 @@
 
   <default>
     <ReverbSync>
+      <extensionOption_group>
+        <!-- By default, logging will be turned off to prevent bloating of log files on client servers -->
+        <enable_logging>0</enable_logging>
+      </extensionOption_group>
       <reverbDefault>
         <enable_listing_creation>0</enable_listing_creation>
         <require_reverb_category_definition>0</require_reverb_category_definition>

--- a/app/code/community/Reverb/ReverbSync/etc/system.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/system.xml
@@ -45,6 +45,18 @@
               <source_model>adminhtml/system_config_source_yesno</source_model>
               <tooltip>Please Select Yes to Enable this Module</tooltip>
             </module_select>
+            <enable_logging translate="label tooltip comment">
+                <depends><module_select>1</module_select></depends>
+                <label>Enable Logging for Reverb Module:</label>
+                <comment>Select Yes/No to enable/disable logging for the Reverb module</comment>
+                <frontend_type>select</frontend_type>
+                <sort_order>1010</sort_order>
+                <show_in_default>1</show_in_default>
+                <show_in_website>1</show_in_website>
+                <show_in_store>1</show_in_store>
+                <source_model>adminhtml/system_config_source_yesno</source_model>
+                <tooltip>Please Select Yes to Enable logging for this Module</tooltip>
+            </enable_logging>
           </fields>
         </extensionOption_group>
 


### PR DESCRIPTION
Fix #268 Creating configuration setting to disable logging of the Reverb module
Any errors which require immediate technical attention will still be logged. This simply removes logging of messaging which is meant more for debugging purposes. 

Tested this on 1.9 and 1.7 and it looks good to go