### PR TITLE
Use Oauth header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.8
+
+* Uses Oauth header for authentication so that shops can generate their own tokens that do not change during password change
+
 ## 0.9.7
 
 * Fixes issues loading the categories screen due to migration problems

--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Please follow the instructions below to download and install the app. This assum
 export MAGENTO_PATH=/path/to/magento
 
 # Download the release
-cd /tmp && wget https://github.com/reverbdotcom/magento/archive/0.9.7.tar.gz
+cd /tmp && wget https://github.com/reverbdotcom/magento/archive/0.9.8.tar.gz
 
 # Unzip the release
-tar zxvf 0.9.7.tar.gz
+tar zxvf 0.9.8.tar.gz
 
 # Copy everything from the app folder into your magento app
-rsync -avzp magento-0.9.7/app/* $MAGENTO_PATH/htdocs/app/
+rsync -avzp magento-0.9.8/app/* $MAGENTO_PATH/htdocs/app/
 
 # Clear your cache
 rm -rf $MAGENTO_PATH/htdocs/var/cache

--- a/app/code/community/Reverb/ReverbSync/Helper/Data.php
+++ b/app/code/community/Reverb/ReverbSync/Helper/Data.php
@@ -420,7 +420,7 @@ class Reverb_ReverbSync_Helper_Data
         $options_array[CURLOPT_RETURNTRANSFER] = 1;
 
         $x_auth_token = Mage::getStoreConfig('ReverbSync/extension/api_token');
-        $options_array[CURLOPT_HTTPHEADER] = array("X-Auth-Token: $x_auth_token", "Content-type: application/hal+json");
+        $options_array[CURLOPT_HTTPHEADER] = array("Authorization: Bearer $x_auth_token", "Content-type: application/hal+json");
 
         $options_array[CURLOPT_URL] = $url;
 

--- a/app/code/community/Reverb/ReverbSync/Model/Adapter/Curl.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Adapter/Curl.php
@@ -11,7 +11,7 @@ class Reverb_ReverbSync_Model_Adapter_Curl
     const POST_DATA_ARGUMENT_TEMPLATE = "--data '%s'";
     const POST_ERROR_LOG_TEMPLATE = 'The following error occurred with the post above: %s';
     const CURL_ERROR_TEMPLATE = "Curl error number %s occurred with the following error message: %s";
-    const USER_AGENT_TEMPLATE = 'Reverb-Magento ReverbMagentoVersion=0.9.7 MagentoVersion=%s MagentoDomain=%s';
+    const USER_AGENT_TEMPLATE = 'Reverb-Magento ReverbMagentoVersion=0.9.8 MagentoVersion=%s MagentoDomain=%s';
     const MAGENTO_VERSION_TEMPLATE = '%s';
 
     const PUT_CUSTOM_REQUEST_VALUE = 'PUT';

--- a/app/code/community/Reverb/ReverbSync/etc/system.xml
+++ b/app/code/community/Reverb/ReverbSync/etc/system.xml
@@ -17,7 +17,7 @@
   </tabs>
   <sections>
     <ReverbSync translate="label" module="ReverbSync">
-      <label>Reverb Configuration (v0.9.7)</label>
+      <label>Reverb Configuration (v0.9.8)</label>
       <tab>ReverbSync</tab>
       <sort_order>1</sort_order>
       <show_in_default>2</show_in_default>


### PR DESCRIPTION
All the tokens now are Oauth compatable, so we should use the Oauth header. This will also allow people to generate tokens for Magento