### PR TITLE
Update Tracking.php

### DIFF
--- a/app/code/community/Reverb/ReverbSync/Model/Sync/Shipment/Tracking.php
+++ b/app/code/community/Reverb/ReverbSync/Model/Sync/Shipment/Tracking.php
@@ -21,6 +21,23 @@ class Reverb_ReverbSync_Model_Sync_Shipment_Tracking extends Reverb_ProcessQueue
         'ups' => 'UPS',
         'usps' => 'USPS',
         'canada_post' => 'Canada Post',
+        'dpd_uk' => 'DPD UK',
+        'dpd_france' => 'DPD France',
+        'dpd_germany' => 'DPD Germany',
+        'ukraine_post' => 'Ukraine Post',
+        'correos_espana' => 'Correos España',
+        'interlogistica' => 'Interlogistica',
+        'purolator' => 'Purolator',
+        'parcelforce' => 'Parcelforce',
+        'china_post' => 'China Post',
+        'la_poste' => 'La Poste',
+        'gls' => 'GLS',
+        'ems' => 'EMS',
+        'australia_post' => 'Australia Post',
+        'post_nl' => 'PostNL',
+        'royal_mail' => 'Royal Mail',
+        'dhl_deutschland' => 'DHL Deutschland',
+        'dhl_express' => 'DHLExpress',
     );
 
     public function transmitTrackingDataToReverb(stdClass $argumentsObject)


### PR DESCRIPTION
Added several international carriers to the shipping sync to ensure proper carriers are automatically pulled in. Credit to Erik B for adding the proper code as an example from the Magento 2.x plugin.